### PR TITLE
Add retry to Control4 APIs that are seeing errors

### DIFF
--- a/custom_components/control4/const.py
+++ b/custom_components/control4/const.py
@@ -13,6 +13,8 @@ DEFAULT_ALARM_CUSTOM_BYPASS_MODE = "(not set)"
 CONF_ALARM_VACATION_MODE = "alarm_vacation_mode"
 DEFAULT_ALARM_VACATION_MODE = "(not set)"
 
+API_RETRY_TIMES = 5
+
 CONF_ACCOUNT = "account"
 CONF_DIRECTOR = "director"
 CONF_WEBSOCKET = "websocket"


### PR DESCRIPTION
This should resolve the issue with refreshing the token reported in https://github.com/lawtancool/hass-control4/issues/14

This was address in the core version in home-assistant/core/pull/113857. This change is an attempt to port that one over.