### PR TITLE
Support for media browsing and playing on Control4 media players

### DIFF
--- a/custom_components/control4/media_player.py
+++ b/custom_components/control4/media_player.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 import enum
 from functools import cached_property
+import json
 import logging
 from typing import Any
 
@@ -13,6 +14,7 @@ from pyControl4.error_handling import C4Exception
 from pyControl4.room import C4Room
 
 from homeassistant.components.media_player import (
+    BrowseMedia,
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
 )
@@ -44,7 +46,6 @@ CONTROL4_PLAYING = "PLAYING"
 CONTROL4_PAUSED = "PAUSED"
 CONTROL4_STOPPED = "STOPPED"
 CONTROL4_MEDIA_INFO = "CURRENT MEDIA INFO"
-
 CONTROL4_PARENT_ID = "parentId"
 
 VARIABLES_OF_INTEREST = {
@@ -61,6 +62,9 @@ VARIABLES_OF_INTEREST = {
 CONTROL4_MEDIA_JOIN_EVENT = "control4_media_join"
 CONTROL4_MEDIA_JOIN_EVENT_ENTITIES = "joining_entities"
 CONTROL4_MEDIA_JOIN_EVENT_SOURCE_IDX = "source_idx"
+CONTROL4_BROWSE_ROOT = f"{DOMAIN}_browse_root"
+CONTROL4_BROWSE_MODE = f"{DOMAIN}_browse_mode"
+CONTROL4_BROWSE_COMMAND = f"{DOMAIN}_browse_command"
 
 
 class _SourceType(enum.Enum):
@@ -132,7 +136,6 @@ async def async_setup_entry(
 
     ui_config = entry_data[CONF_UI_CONFIGURATION]
     sources: dict[int, _RoomSource] = {}
-
     entity_list = []
     for room in all_rooms:
         room_id = room["id"]
@@ -233,6 +236,8 @@ class Control4Room(Control4CoordinatorEntity, MediaPlayerEntity):  # type: ignor
             | MediaPlayerEntityFeature.TURN_OFF
             | MediaPlayerEntityFeature.SELECT_SOURCE
             | MediaPlayerEntityFeature.GROUPING
+            | MediaPlayerEntityFeature.BROWSE_MEDIA
+            | MediaPlayerEntityFeature.PLAY_MEDIA
         )
         self._current_source: _RoomSource | None = None
         self.hass.bus.async_listen(CONTROL4_MEDIA_JOIN_EVENT,
@@ -507,4 +512,237 @@ class Control4Room(Control4CoordinatorEntity, MediaPlayerEntity):  # type: ignor
     async def async_media_stop(self):
         """Issue a stop command."""
         await self._create_api_object().set_stop()
+        await self.coordinator.async_request_refresh()
+
+    def _filter_browse_items_for_room(
+        self,
+        items: list[dict[str, Any]],
+        mode: str,
+    ) -> list[dict[str, Any]]:
+        """Filter browse items to sources available in this room."""
+        source_type = _SourceType.AUDIO if mode == "listen" else _SourceType.VIDEO
+        allowed_source_ids = {
+            source.idx
+            for source in self._sources.values()
+            if source_type in source.source_type
+        }
+        if not allowed_source_ids:
+            return items
+
+        filtered: list[dict[str, Any]] = []
+        matched_source_item = False
+        for item in items:
+            device_id = item.get("device_id")
+            if isinstance(device_id, int):
+                if device_id in allowed_source_ids:
+                    matched_source_item = True
+                    filtered.append(item)
+                continue
+            filtered.append(item)
+
+        if matched_source_item:
+            return filtered
+        return items
+
+    async def _get_browse_commands(self, mode: str) -> list[dict[str, Any]]:
+        """Build the browse command list for Listen or Watch."""
+        room = self._create_api_object()
+        command_data = await room.get_commands()
+        commands: list[dict[str, Any]] = []
+        for command in command_data:
+            command_name = command.get("command")
+            if not isinstance(command_name, str):
+                continue
+            media_type_value = None
+            if ":" in command_name:
+                command_name, media_type_value = command_name.split(":", 1)
+            if mode == "listen" and not command_name.startswith("SELECT_AUDIO_"):
+                continue
+            if mode == "watch" and not command_name.startswith("SELECT_VIDEO_"):
+                continue
+            params = command.get("params", [])
+            if not isinstance(params, list):
+                continue
+            path = None
+            param_name = "mediaid"
+            value_field = "id"
+            defaults = {}
+            for param in params:
+                if not isinstance(param, dict):
+                    continue
+                value_src = param.get("valueSrc")
+                if path is None and isinstance(value_src, dict) and "path" in value_src:
+                    path = value_src["path"]
+                    param_name = param.get("name", "mediaid")
+                    value_field = param.get("valueField", "id")
+                    continue
+                name = param.get("name")
+                if not isinstance(name, str):
+                    continue
+                if "value" in param:
+                    value = param["value"]
+                    if isinstance(value, dict) and "static" in value:
+                        defaults[name] = value["static"]
+                    else:
+                        defaults[name] = value
+            if not isinstance(path, str):
+                continue
+            if media_type_value and "type" not in defaults:
+                defaults["type"] = media_type_value
+            commands.append(
+                {
+                    "mode": mode,
+                    "command": command_name,
+                    "title": command.get("label", command_name),
+                    "path": path,
+                    "param_name": param_name,
+                    "value_field": value_field,
+                    "defaults": defaults,
+                }
+            )
+        return commands
+
+    async def _browse_mode(self, mode: str) -> BrowseMedia:
+        """Build the Listen/Watch folder in browse."""
+        commands = await self._get_browse_commands(mode)
+        children = []
+        for command in commands:
+            children.append(
+                BrowseMedia(
+                    title=command["title"],
+                    media_class="directory",
+                    media_content_type=CONTROL4_BROWSE_COMMAND,
+                    media_content_id=json.dumps(command),
+                    can_play=False,
+                    can_expand=True,
+                )
+            )
+        title = "Listen" if mode == "listen" else "Watch"
+        return BrowseMedia(
+            title=title,
+            media_class="directory",
+            media_content_type=CONTROL4_BROWSE_MODE,
+            media_content_id=mode,
+            can_play=False,
+            can_expand=True,
+            children=children,
+        )
+
+    async def _browse_command(self, media_content_id: str) -> BrowseMedia:
+        """Build the selectable items for one browse command.
+
+        media_content_id is the serialized command dict from _browse_mode. Each
+        child stores a play payload like {"command": ..., "params": {...}}.
+        """
+        command_data = json.loads(media_content_id)
+        path = command_data["path"]
+        room = self._create_api_object()
+        mode = command_data.get("mode", "listen")
+        items = await room.get_browse_items(path)
+        items = self._filter_browse_items_for_room(items, mode)
+
+        param_name = command_data["param_name"]
+        value_field = command_data["value_field"]
+        defaults = command_data.get("defaults", {})
+        command = command_data["command"]
+
+        children = []
+        for item in items:
+            if value_field not in item:
+                continue
+            params = dict(defaults)
+            params[param_name] = item[value_field]
+            play_payload = {"command": command, "params": params}
+            children.append(
+                BrowseMedia(
+                    title=item.get("name"),
+                    media_class="track" if mode == "listen" else "video",
+                    media_content_type=MediaType.MUSIC if mode == "listen" else MediaType.VIDEO,
+                    media_content_id=json.dumps(play_payload),
+                    can_play=True,
+                    can_expand=False,
+                )
+            )
+
+        return BrowseMedia(
+            title=command_data["title"],
+            media_class="directory",
+            media_content_type=CONTROL4_BROWSE_COMMAND,
+            media_content_id=media_content_id,
+            can_play=False,
+            can_expand=True,
+            children=children,
+        )
+
+    async def async_browse_media(
+        self, media_content_type: str | None = None, media_content_id: str | None = None
+    ) -> BrowseMedia:
+        """Return the browse root, or drill into a child node."""
+        if media_content_type == CONTROL4_BROWSE_MODE and media_content_id:
+            return await self._browse_mode(media_content_id)
+        if media_content_type == CONTROL4_BROWSE_COMMAND and media_content_id:
+            return await self._browse_command(media_content_id)
+
+        children = []
+        has_listen = any(
+            _SourceType.AUDIO in source.source_type for source in self._sources.values()
+        )
+        has_watch = any(
+            _SourceType.VIDEO in source.source_type for source in self._sources.values()
+        )
+        if has_listen:
+            children.append(
+                BrowseMedia(
+                    title="Listen",
+                    media_class="directory",
+                    media_content_type=CONTROL4_BROWSE_MODE,
+                    media_content_id="listen",
+                    can_play=False,
+                    can_expand=True,
+                )
+            )
+        if has_watch:
+            children.append(
+                BrowseMedia(
+                    title="Watch",
+                    media_class="directory",
+                    media_content_type=CONTROL4_BROWSE_MODE,
+                    media_content_id="watch",
+                    can_play=False,
+                    can_expand=True,
+                )
+            )
+        return BrowseMedia(
+            title=self._device_name or self.name or "Control4",
+            media_class="directory",
+            media_content_type=CONTROL4_BROWSE_ROOT,
+            media_content_id="root",
+            can_play=False,
+            can_expand=True,
+            children=children,
+        )
+
+    async def async_play_media(self, media_type: str, media_id: str, **kwargs) -> None:
+        """Run a play payload selected from browse.
+
+        Home Assistant passes media_id as a string, so browse nodes store the
+        Control4 command payload in media_content_id as JSON text.
+
+        Expected media_id format:
+        {"command": "SELECT_AUDIO_MEDIA", "params": {"mediaid": 276, "deselect": "1"}}
+        """
+        try:
+            payload = json.loads(media_id)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(payload, dict):
+            return
+        command = payload.get("command")
+        if not isinstance(command, str):
+            return
+        params = payload.get("params", {})
+        if not isinstance(params, dict):
+            params = {}
+        room = self._create_api_object()
+        await room.play_browse_item(command, params)
         await self.coordinator.async_request_refresh()


### PR DESCRIPTION
This adds support for browsing Control4 media in HA. For example, if you have Spotify or iHeart Radio favorites these will be browsable and playable from the HA media player. This requires some updates to pyControl4, there's a PR for that over there. 