### PR TITLE
Import roomName/floorName from c4 as area/floor in HA

### DIFF
--- a/custom_components/control4/config_flow.py
+++ b/custom_components/control4/config_flow.py
@@ -1,6 +1,11 @@
 """Config flow for Control4 integration."""
-from asyncio import TimeoutError as asyncioTimeoutError
+from __future__ import annotations
+
+import asyncio
+import json
 import logging
+from asyncio import TimeoutError as asyncioTimeoutError
+from typing import Any
 
 from aiohttp.client_exceptions import ClientError
 from pyControl4.account import C4Account
@@ -15,8 +20,13 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_SCAN_INTERVAL,
 )
-from homeassistant.core import callback
-from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import (
+    aiohttp_client,
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.device_registry import format_mac
 
 from .const import (
@@ -27,6 +37,8 @@ from .const import (
     CONF_ALARM_NIGHT_MODE,
     CONF_ALARM_VACATION_MODE,
     CONF_CONTROLLER_UNIQUE_ID,
+    CONF_DIRECTOR_ALL_ITEMS,
+    CONTROL4_ENTITY_TYPE,
     DEFAULT_ALARM_AWAY_MODE,
     DEFAULT_ALARM_CUSTOM_BYPASS_MODE,
     DEFAULT_ALARM_HOME_MODE,
@@ -36,8 +48,94 @@ from .const import (
     DOMAIN,
     MIN_SCAN_INTERVAL,
 )
+from .director_utils import director_get_entry_variables, director_get_item_properties
+from .location_floor import (
+    LOCATION_FLOOR_FEATURES_AVAILABLE,
+    _format_table,
+    async_apply_area_floor_to_ha,
+    async_build_location_floor_table,
+    format_table_markdown,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def build_control4_export_payload(
+    hass: HomeAssistant, entry_id: str
+) -> dict[str, Any] | None:
+    """Build export payload (meta + items with variables and properties) for the given config entry."""
+    entry_data = (hass.data.get(DOMAIN) or {}).get(entry_id)
+    if not entry_data:
+        return None
+    data = entry_data.get(CONF_DIRECTOR_ALL_ITEMS)
+    if not data:
+        return None
+    entry = next(
+        (e for e in hass.config_entries.async_entries(DOMAIN) if e.entry_id == entry_id),
+        None,
+    )
+    if not entry:
+        return None
+
+    export_list = [dict(item) for item in data]
+    device_indices = [
+        i
+        for i, item in enumerate(export_list)
+        if item.get("type") == CONTROL4_ENTITY_TYPE and item.get("id")
+    ]
+
+    async def fetch_vars(index: int) -> tuple[int, dict[str, Any]]:
+        item = export_list[index]
+        item_id = item["id"]
+        try:
+            variables = await director_get_entry_variables(hass, entry, item_id)
+            return (index, variables)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Export: failed to get variables for item %s: %s", item_id, err)
+            return (index, {"_error": str(err)})
+
+    batch_size = 20
+    for start in range(0, len(device_indices), batch_size):
+        batch = device_indices[start : start + batch_size]
+        results = await asyncio.gather(*(fetch_vars(i) for i in batch))
+        for index, variables in results:
+            export_list[index]["variables"] = variables
+
+    # Director properties per item (user-triggered export; not a hot path).
+    properties_indices = [
+        i for i, item in enumerate(export_list) if item.get("id") is not None
+    ]
+
+    async def fetch_props(index: int) -> tuple[int, dict[str, Any] | None]:
+        item = export_list[index]
+        item_id = item["id"]
+        props = await director_get_item_properties(hass, entry, item_id)
+        return (index, props)
+
+    for start in range(0, len(properties_indices), batch_size):
+        batch = properties_indices[start : start + batch_size]
+        results = await asyncio.gather(*(fetch_props(i) for i in batch))
+        for index, props in results:
+            export_list[index]["properties"] = props
+
+    dev_reg = dr.async_get(hass)
+    ha_device_count = sum(
+        1 for d in dev_reg.devices.values() if entry.entry_id in d.config_entries
+    )
+    entity_reg = er.async_get(hass)
+    ha_entities: dict[str, int] = {}
+    for entity in entity_reg.entities.values():
+        if entity.config_entry_id != entry.entry_id:
+            continue
+        platform = entity.platform or "unknown"
+        ha_entities[platform] = ha_entities.get(platform, 0) + 1
+
+    return {
+        "meta": {"ha_device_count": ha_device_count, "ha_entities": ha_entities},
+        "items": export_list,
+    }
+
+
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -200,8 +298,192 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         # Do not assign to self.config_entry; it's a read-only property in HA.
         self._config_entry = config_entry
 
+    def _entry_data_ready(self):
+        """Return True if integration entry data is loaded (for table/apply)."""
+        entry_data = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
+        return bool(entry_data and entry_data.get(CONF_DIRECTOR_ALL_ITEMS))
+
+    @staticmethod
+    def _options_menu_choices() -> dict[str, str]:
+        """Build init-step menu; area/floor/export require floor registry (HA 2024.3+)."""
+        menu = {
+            "configure": "Configure options (scan interval, alarm modes)",
+        }
+        if LOCATION_FLOOR_FEATURES_AVAILABLE:
+            menu["table"] = "Show c4 device area/floor"
+            menu["apply"] = "Apply c4 device area/floor to HA"
+            menu["export_file"] = (
+                "Write director export JSON to configuration folder"
+            )
+        return menu
+
+    async def _notify_and_close(self, title: str, message: str, notification_id: str):
+        """Send a persistent notification and close the options flow."""
+        await self.hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {
+                "title": title,
+                "message": message,
+                "notification_id": notification_id,
+            },
+        )
+        return self.async_create_entry(title="", data=self._config_entry.options)
+
+    async def _handle_show_table(self):
+        """Build area/floor table, send notification, and close flow."""
+        try:
+            rows = await async_build_location_floor_table(
+                self.hass, self._config_entry
+            )
+            full_table = _format_table(rows, max_rows=999)
+            notification_table = format_table_markdown(rows, max_rows=150)
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.exception("Failed to build area/floor table: %s", err)
+            full_table = f"(Error: {err})"
+            notification_table = f"_Error: {err}_"
+        _LOGGER.info(
+            "Control4 area/floor mapping (full table):\n%s",
+            full_table,
+        )
+        return await self._notify_and_close(
+            "Control4 area/floor mapping",
+            notification_table,
+            "control4_area_floor_table",
+        )
+
+    def _format_apply_message(self, summary: dict) -> str:
+        """Build the notification message from apply summary."""
+        created_f = summary.get("created_floors") or []
+        created_a = summary.get("created_areas") or []
+        updated = summary.get("updated_devices") or 0
+        mismatched = summary.get("mismatched_after_apply", 0)
+        errs = summary.get("errors") or []
+        skipped = summary.get("skipped_no_area") or []
+        skipped_room = summary.get("skipped_no_c4_room") or []
+        msg = (
+            f"- **Floors created:** {len(created_f)}\n"
+            f"- **Areas created:** {len(created_a)}\n"
+            f"- **Devices assigned:** {updated}\n"
+            f"- **C4 devices with room/floor different from HA:** {mismatched}\n"
+        )
+        if skipped_room:
+            msg += (
+                f"\n**Skipped (C4 has no room name, no HA area):** "
+                f"{len(skipped_room)} entities (IDs: {', '.join(str(x) for x in skipped_room[:30])}"
+            )
+            if len(skipped_room) > 30:
+                msg += ", …"
+            msg += ")\n"
+        if skipped:
+            msg += f"\n**Skipped (no area for location):** {len(skipped)} devices\n"
+            for row_id, fl, rm in skipped[:20]:
+                msg += f"- ID {row_id}: floor={fl!r}, room={rm!r}\n"
+            if len(skipped) > 20:
+                msg += f"- ... and {len(skipped) - 20} more\n"
+        if errs:
+            msg += "\n**Errors:**\n" + "\n".join(f"- {e}" for e in errs)
+        return msg
+
+    async def _handle_apply(self):
+        """Run apply area/floor to HA, send result notification, and close flow."""
+        try:
+            summary = await async_apply_area_floor_to_ha(
+                self.hass, self._config_entry
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.exception("Failed to apply area/floor to HA: %s", err)
+            summary = {
+                "errors": [str(err)],
+                "created_floors": [],
+                "created_areas": [],
+                "updated_devices": 0,
+                "skipped_no_area": [],
+                "skipped_no_c4_room": [],
+                "mismatched_after_apply": 0,
+            }
+        msg = self._format_apply_message(summary)
+        return await self._notify_and_close(
+            "Control4 apply area/floor",
+            msg,
+            "control4_apply_area_floor",
+        )
+
+    async def _handle_write_export(self):
+        """Write director export JSON under the HA configuration directory."""
+        entry_id = self._config_entry.entry_id
+        payload = await build_control4_export_payload(self.hass, entry_id)
+        if not payload:
+            return await self._notify_and_close(
+                "Control4 export",
+                "Export data is not available. Wait for the Control4 integration to finish loading, then try again.",
+                "control4_export_json",
+            )
+        filename = f"control4_director_export_{entry_id}.json"
+        path = self.hass.config.path(filename)
+
+        def _write() -> None:
+            with open(path, "w", encoding="utf-8") as fp:
+                json.dump(payload, fp, indent=2, ensure_ascii=False, default=str)
+
+        try:
+            await self.hass.async_add_executor_job(_write)
+        except OSError as err:
+            _LOGGER.exception("Failed to write Control4 export: %s", err)
+            return await self._notify_and_close(
+                "Control4 export",
+                f"Could not write export file: {err}",
+                "control4_export_json",
+            )
+        return await self._notify_and_close(
+            "Control4 export",
+            f"Wrote director export JSON to:\n\n`{path}`",
+            "control4_export_json",
+        )
+
     async def async_step_init(self, user_input=None):
-        """Handle options flow."""
+        """Handle options flow: menu to choose configure or show table."""
+        choices = self._options_menu_choices()
+        if user_input is not None:
+            choice = user_input.get("Settings")
+            if choice == "table" and LOCATION_FLOOR_FEATURES_AVAILABLE:
+                if not self._entry_data_ready():
+                    return await self._notify_and_close(
+                        "Control4 area/floor mapping",
+                        "Integration data is not ready. Please try again after the integration has finished loading.",
+                        "control4_area_floor_table",
+                    )
+                return await self._handle_show_table()
+            if choice == "apply" and LOCATION_FLOOR_FEATURES_AVAILABLE:
+                if not self._entry_data_ready():
+                    return await self._notify_and_close(
+                        "Control4 apply area/floor",
+                        "Integration data is not ready. Please try again after the integration has finished loading.",
+                        "control4_apply_area_floor",
+                    )
+                return await self._handle_apply()
+            if choice == "export_file" and LOCATION_FLOOR_FEATURES_AVAILABLE:
+                if not self._entry_data_ready():
+                    return await self._notify_and_close(
+                        "Control4 export",
+                        "Integration data is not ready. Please try again after the integration has finished loading.",
+                        "control4_export_json",
+                    )
+                return await self._handle_write_export()
+            return await self.async_step_configure()
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("Settings", default="configure"): vol.In(choices),
+                }
+            ),
+            description_placeholders={"heading": "Control4 settings"},
+        )
+
+    async def async_step_configure(self, user_input=None):
+        """Handle the configure-options form (scan interval, alarm modes)."""
         if user_input is not None:
             _LOGGER.debug(user_input)
             return self.async_create_entry(title="", data=user_input)
@@ -214,7 +496,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         arm_state_choices = set(self.entry_data.get(CONF_ALARM_ARM_STATES, [])) or {
             DEFAULT_ALARM_AWAY_MODE
         }
-
         # Determine if a security panel is effectively present (has real arm states)
         has_security = any(
             x.strip() and x.strip() != DEFAULT_ALARM_AWAY_MODE for x in arm_state_choices
@@ -275,7 +556,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 },
                 required=False,
             )
-        return self.async_show_form(step_id="init", data_schema=data_schema)
+        return self.async_show_form(step_id="configure", data_schema=data_schema)
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/custom_components/control4/director_utils.py
+++ b/custom_components/control4/director_utils.py
@@ -1,11 +1,16 @@
 """Provides data updates from the Control4 controller for platforms."""
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from typing import Any
+import logging
 from collections import defaultdict
 from collections.abc import Set
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
 
 from .const import CONF_DIRECTOR, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def director_get_entry_variables(
@@ -31,3 +36,35 @@ async def update_variables_for_config_entry(
     for item in data:
         result_dict[item["id"]][item["varName"]] = item["value"]
     return dict(result_dict)
+
+
+async def director_get_item_properties(
+    hass: HomeAssistant, entry: ConfigEntry, item_id: int
+) -> dict[str, Any] | None:
+    """Retrieve Director properties for a Control4 item (e.g. area/channel for Dynalite)."""
+    entry_data = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
+    if not entry_data:
+        return None
+    director = entry_data.get(CONF_DIRECTOR)
+    if not director:
+        return None
+    url = f"{director.base_url}/api/v1/items/{item_id}/properties"
+    session = aiohttp_client.async_get_clientsession(hass, verify_ssl=False)
+    headers = {"Authorization": f"Bearer {director.director_bearer_token}"}
+    try:
+        async with session.get(url, headers=headers) as resp:
+            if resp.status == 200:
+                return await resp.json()
+            _LOGGER.debug(
+                "Export: properties for item %s returned status %s",
+                item_id,
+                resp.status,
+            )
+            return None
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug(
+            "Export: failed to get properties for item %s: %s",
+            item_id,
+            err,
+        )
+        return None

--- a/custom_components/control4/location_floor.py
+++ b/custom_components/control4/location_floor.py
@@ -1,0 +1,454 @@
+"""Helpers to map C4 room/floor to HA Area/Floor and build a combined report table.
+
+WHAT: Maps Control4 (C4) room/floor from the director to Home Assistant (HA) areas
+and floors. Supports building a report table (show in notification) and applying
+C4 locations to HA (create areas/floors, assign devices).
+
+WHY: C4 devices live in rooms/floors; HA uses areas and (optionally) floors. This
+lets users see the mapping and one-shot sync C4 locations into HA so devices
+appear in the right area/floor in the UI.
+
+HOW: Uses director_all_items (C4 project data) for roomName/floorName with a
+parent-walk when an item has none. Uses HA entity/device/area/floor registries for
+current HA state. Apply creates missing floors/areas by name and assigns devices.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+
+from .const import CONF_DIRECTOR_ALL_ITEMS, DOMAIN
+
+try:
+    from homeassistant.helpers import floor_registry as fr
+except ImportError:
+    fr = None  # Floor registry added in HA 2024.3; older HA has no floors
+
+# Area/floor mapping and floor-aware apply require the floor registry (HA 2024.3+).
+LOCATION_FLOOR_FEATURES_AVAILABLE: bool = fr is not None
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# C4 location lookup (director data)
+# -----------------------------------------------------------------------------
+
+
+def get_c4_room_floor_from_map(
+    items_by_id: dict[int, dict], item_id: int
+) -> tuple[str, str]:
+    """Return (roomName, floorName) for a C4 item id using a prebuilt id→item map.
+
+    Rationale: In C4, only some items (e.g. room, device) have roomName/floorName;
+    child items may not. We walk parentId until we find an item that has location
+    so every entity gets a consistent room/floor from its hierarchy.
+    """
+    current_id: int | None = item_id
+    while current_id is not None:
+        item = items_by_id.get(current_id)
+        if not item:
+            return ("", "")
+        room_name = item.get("roomName") or ""
+        floor_name = item.get("floorName") or ""
+        if room_name or floor_name:
+            return (room_name, floor_name)
+        current_id = item.get("parentId")
+    return ("", "")
+
+
+def get_c4_room_floor(director_all_items: list[dict], item_id: int) -> tuple[str, str]:
+    """Same as get_c4_room_floor_from_map but builds the map (O(items)); prefer the _from_map API in hot loops."""
+    items_by_id = {item["id"]: item for item in director_all_items if item.get("id")}
+    return get_c4_room_floor_from_map(items_by_id, item_id)
+
+
+def get_ha_area_floor_for_device(
+    hass: HomeAssistant, device: dr.DeviceEntry | None
+) -> tuple[str, str]:
+    """Return (area_name, floor_name) for a device registry entry. Returns ("", "") when not set."""
+    if not device or not device.area_id:
+        return ("", "")
+
+    area_reg = ar.async_get(hass)
+    area = area_reg.async_get_area(device.area_id)
+    if not area:
+        return ("", "")
+
+    area_name = area.name or ""
+    floor_name = ""
+    if fr and area.floor_id:
+        floor_reg = fr.async_get(hass)
+        floor = floor_reg.async_get_floor(area.floor_id)
+        if floor:
+            floor_name = floor.name or ""
+
+    return (area_name, floor_name)
+
+
+def get_ha_area_floor(hass: HomeAssistant, device_id: str) -> tuple[str, str]:
+    """Return (area_name, floor_name) for a HA device id using registries.
+
+    Device is looked up by (DOMAIN, device_id). Returns ("", "") when not set.
+    """
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
+    return get_ha_area_floor_for_device(hass, device)
+
+
+# -----------------------------------------------------------------------------
+# Table formatting (log + notification)
+# -----------------------------------------------------------------------------
+
+TABLE_HEADERS = ["id", "entity_id", "name", "ha_area", "ha_floor", "c4_room", "c4_floor"]
+
+
+def _format_table(rows: list[dict[str, Any]], max_rows: int = 100) -> str:
+    """Format rows as a fixed-width table for logging. Why: readable in logs."""
+    if not rows:
+        return "(no entities)"
+
+    col_widths = {
+        "id": 6,
+        "entity_id": 28,
+        "name": 22,
+        "ha_area": 14,
+        "ha_floor": 14,
+        "c4_room": 14,
+        "c4_floor": 14,
+    }
+    lines = []
+    header_line = "  ".join(h.ljust(col_widths[h]) for h in TABLE_HEADERS)
+    lines.append(header_line)
+    lines.append("-" * len(header_line))
+
+    for i, row in enumerate(rows):
+        if i >= max_rows:
+            lines.append(f"... and {len(rows) - max_rows} more entities")
+            break
+        parts = []
+        for key in TABLE_HEADERS:
+            val = str((row.get(key) or ""))[: col_widths[key]]
+            parts.append(val.ljust(col_widths[key]))
+        lines.append("  ".join(parts))
+
+    return "\n".join(lines)
+
+
+def format_table_markdown(rows: list[dict[str, Any]], max_rows: int = 150) -> str:
+    """Format rows as markdown for persistent_notification. Why: HA renders markdown as a table."""
+    if not rows:
+        return "_No entities_"
+
+    def escape_cell(val: Any) -> str:
+        s = str(val or "").replace("|", "\\|").replace("\n", " ")
+        return s[:50] if len(s) > 50 else s
+
+    header_row = "| " + " | ".join(TABLE_HEADERS) + " |"
+    separator = "|" + "|".join("---" for _ in TABLE_HEADERS) + "|"
+
+    lines = [header_row, separator]
+    for i, row in enumerate(rows):
+        if i >= max_rows:
+            lines.append(f"| _… and {len(rows) - max_rows} more_ |" + " |" * (len(TABLE_HEADERS) - 1))
+            break
+        cells = [escape_cell(row.get(h)) for h in TABLE_HEADERS]
+        lines.append("| " + " | ".join(cells) + " |")
+
+    return "\n".join(lines)
+
+
+# -----------------------------------------------------------------------------
+# Build combined table (HA entities + C4 and HA location)
+# -----------------------------------------------------------------------------
+
+
+async def async_build_location_floor_table(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> list[dict[str, Any]]:
+    """Build a combined table of C4 entities with HA and C4 area/floor.
+
+    Only includes rows for HA entities that belong to this config entry (entity
+    registry). Items without an HA entity (e.g. unsupported device types, or
+    entities skipped due to non-integer unique_id / no device_id / device not
+    in registry) do not appear. Returns a list of dicts: id, name, ha_area,
+    ha_floor, c4_room, c4_floor (and optionally device_id for later use).
+    Sorted by id.
+    """
+    # Why: table is entity-centric so "Show table" and "Apply" only deal with
+    # devices that actually have HA entities.
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if not entry_data:
+        _LOGGER.debug("No entry data for config entry %s", entry.entry_id)
+        return []
+
+    director_all_items = entry_data.get(CONF_DIRECTOR_ALL_ITEMS)
+    if not director_all_items:
+        _LOGGER.warning("No director_all_items for config entry %s", entry.entry_id)
+        return []
+
+    entity_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+
+    items_by_id = {
+        item["id"]: item for item in director_all_items if item.get("id")
+    }
+
+    rows: list[dict[str, Any]] = []
+    for entity in entity_reg.entities.values():
+        if entity.config_entry_id != entry.entry_id:
+            continue
+
+        try:
+            item_id = int(entity.unique_id)
+        except (ValueError, TypeError):
+            continue
+
+        device_id = entity.device_id
+        if not device_id:
+            continue
+
+        device = dev_reg.async_get(device_id)
+        if not device:
+            continue
+
+        # HA device_id is registry-internal; C4 uses (DOMAIN, parent_item_id). Get it from identifiers.
+        c4_device_id = ""
+        for ident in device.identifiers:
+            if ident[0] == DOMAIN:
+                c4_device_id = str(ident[1])
+                break
+
+        ha_area, ha_floor = get_ha_area_floor_for_device(hass, device)
+        c4_room, c4_floor = get_c4_room_floor_from_map(items_by_id, item_id)
+
+        name = entity.original_name or entity.name or device.name_by_user or device.name or ""
+        entity_id = entity.entity_id or ""
+
+        rows.append(
+            {
+                "id": item_id,
+                "entity_id": entity_id,
+                "name": name,
+                "ha_area": ha_area,
+                "ha_floor": ha_floor,
+                "c4_room": c4_room,
+                "c4_floor": c4_floor,
+                "device_id": device.id,
+                "c4_device_id": c4_device_id,
+            }
+        )
+
+    rows.sort(key=lambda r: r["id"])
+    return rows
+
+
+# -----------------------------------------------------------------------------
+# Apply: create HA areas/floors from C4 and assign devices
+# -----------------------------------------------------------------------------
+
+def _normalize(s: str) -> str:
+    """Stripped string; empty for None/whitespace. Why: consistent (floor, room) keys and comparisons."""
+    return (s or "").strip()
+
+
+def _get_floor_id_by_name(hass: HomeAssistant, name: str):
+    """Return floor_id for the given floor name, or None if not found / fr unavailable."""
+    if not name or not fr:
+        return None
+    floor_reg = fr.async_get(hass)
+    for floor in floor_reg.async_list_floors():
+        if (floor.name or "").strip() == name:
+            return floor.floor_id
+    return None
+
+
+def _get_area_id_by_name_and_floor(
+    hass: HomeAssistant, area_name: str, floor_id: str | None
+) -> str | None:
+    """Area by name + floor_id. Why: same name on different floors (e.g. Living Room) are different areas."""
+    area_reg = ar.async_get(hass)
+    for area in area_reg.async_list_areas():
+        if (area.name or "").strip() != area_name:
+            continue
+        if (area.floor_id or None) == floor_id:
+            return area.id
+    return None
+
+
+def _get_area_id_by_name(hass: HomeAssistant, area_name: str) -> str | None:
+    """First area with given name (any floor). Used when create fails with 'already in use' (area exists without floor)."""
+    area_reg = ar.async_get(hass)
+    for area in area_reg.async_list_areas():
+        if (area.name or "").strip() == area_name:
+            return area.id
+    return None
+
+
+async def async_apply_area_floor_to_ha(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Create missing HA areas/floors from C4 and assign devices.
+
+    What: For each (c4_floor, c4_room) that doesn't match HA yet, ensure floor/area
+    exist (by name), then set each device's area_id. Reuses the same table as "Show".
+    Why: One-shot sync so C4 layout is reflected in HA without manual area assignment.
+    Returns: created_floors, created_areas, updated_devices, errors, skipped_no_area,
+    mismatched_after_apply.
+    """
+    summary: dict[str, Any] = {
+        "created_floors": [],
+        "created_areas": [],
+        "updated_devices": 0,
+        "errors": [],
+        "skipped_no_area": [],  # list of (row_id, c4_floor, c4_room) when area_id missing
+        "skipped_no_c4_room": [],  # C4 has no room name; cannot create/sync HA area from C4
+    }
+    rows = await async_build_location_floor_table(hass, entry)
+    if not rows:
+        return summary
+
+    area_reg = ar.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    floor_reg = fr.async_get(hass) if fr else None
+
+    # Collect (floor, room) pairs that need an area; skip already-matching or empty C4 location
+    need_locations: set[tuple[str, str]] = set()
+    for row in rows:
+        c4_room = _normalize(row.get("c4_room") or "")
+        c4_floor = _normalize(row.get("c4_floor") or "")
+        ha_area = _normalize(row.get("ha_area") or "")
+        ha_floor = _normalize(row.get("ha_floor") or "")
+        if not c4_room and not c4_floor:
+            continue
+        if not c4_room:
+            if ha_area:
+                continue
+            summary["skipped_no_c4_room"].append(row.get("id"))
+            continue
+        if ha_area == c4_room and ha_floor == c4_floor:
+            continue
+        need_locations.add((c4_floor, c4_room))
+
+    # Build or find floor and area for each (c4_floor, c4_room); cache for device assignment
+    location_to_area_id: dict[tuple[str, str], str] = {}
+
+    for c4_floor, c4_room in need_locations:
+        floor_id = None
+        if c4_floor and floor_reg:
+            floor_id = _get_floor_id_by_name(hass, c4_floor)
+            if floor_id is None:
+                try:
+                    new_floor = floor_reg.async_create(c4_floor)
+                    floor_id = new_floor.floor_id
+                    summary["created_floors"].append(c4_floor)
+                except Exception as e:  # pylint: disable=broad-except
+                    summary["errors"].append(f"Create floor '{c4_floor}': {e}")
+                    continue
+
+        area_id = _get_area_id_by_name_and_floor(hass, c4_room, floor_id)
+        if area_id is None:
+            try:
+                new_area = area_reg.async_create(c4_room)
+                area_id = new_area.id
+                summary["created_areas"].append(c4_room)
+                if floor_id:
+                    area_reg.async_update(area_id, floor_id=floor_id)
+            except Exception as e:  # pylint: disable=broad-except
+                err_msg = str(e)
+                # Rationale: Area may already exist without floor (e.g. created manually). Use it and link floor.
+                if "already in use" in err_msg.lower():
+                    area_id = _get_area_id_by_name(hass, c4_room)
+                    if area_id and floor_id:
+                        try:
+                            area_reg.async_update(area_id, floor_id=floor_id)
+                        except Exception:  # pylint: disable=broad-except
+                            pass
+                if area_id is None:
+                    summary["errors"].append(f"Create area '{c4_room}': {e}")
+                    continue
+        location_to_area_id[(c4_floor, c4_room)] = area_id
+
+    # Assign each device to the area for its (c4_floor, c4_room)
+    for row in rows:
+        c4_room = _normalize(row.get("c4_room") or "")
+        c4_floor = _normalize(row.get("c4_floor") or "")
+        if not c4_room and not c4_floor:
+            continue
+        if not c4_room:
+            continue
+        ha_area = _normalize(row.get("ha_area") or "")
+        ha_floor = _normalize(row.get("ha_floor") or "")
+        if ha_area == c4_room and ha_floor == c4_floor:
+            continue
+        area_id = location_to_area_id.get((c4_floor, c4_room))
+        if not area_id:
+            summary["skipped_no_area"].append(
+                (row.get("id"), c4_floor, c4_room)
+            )
+            continue
+        device_id = row.get("device_id")
+        if not device_id:
+            continue
+        try:
+            dev_reg.async_update_device(device_id, area_id=area_id)
+            summary["updated_devices"] += 1
+        except Exception as e:  # pylint: disable=broad-except
+            summary["errors"].append(f"Update device {device_id}: {e}")
+
+    # Post-apply: how many entities still have HA != C4 (e.g. skipped or errors)
+    rows_after = await async_build_location_floor_table(hass, entry)
+    mismatched = 0
+    for row in rows_after:
+        c4_room = _normalize(row.get("c4_room") or "")
+        c4_floor = _normalize(row.get("c4_floor") or "")
+        if not c4_room and not c4_floor:
+            continue
+        if not c4_room:
+            continue
+        ha_area = _normalize(row.get("ha_area") or "")
+        ha_floor = _normalize(row.get("ha_floor") or "")
+        if ha_area != c4_room or ha_floor != c4_floor:
+            mismatched += 1
+    summary["mismatched_after_apply"] = mismatched
+
+    return summary
+
+
+async def async_report_area_floor_mapping(
+    hass: HomeAssistant, config_entry_id: str | None = None
+) -> list[dict[str, Any]]:
+    """Build the table, log at INFO, return rows (no device_id in output). For services/callers that need the table only."""
+    entries = hass.config_entries.async_entries(DOMAIN)
+    if not entries:
+        _LOGGER.warning("No Control4 config entries found")
+        return []
+
+    entry = None
+    if config_entry_id:
+        for e in entries:
+            if e.entry_id == config_entry_id:
+                entry = e
+                break
+    if not entry:
+        entry = entries[0]
+
+    rows = await async_build_location_floor_table(hass, entry)
+    table = _format_table(rows)
+    _LOGGER.info(
+        "Control4 area/floor mapping (entry_id=%s):\n%s",
+        entry.entry_id,
+        table,
+    )
+    # Return without internal device_id keys for service response
+    return [
+        {k: v for k, v in row.items() if k not in ("device_id", "c4_device_id")}
+        for row in rows
+    ]

--- a/custom_components/control4/strings.json
+++ b/custom_components/control4/strings.json
@@ -31,6 +31,14 @@
   "options": {
     "step": {
       "init": {
+        "title": "Control4 settings",
+        "description": "{heading}",
+        "data": {
+          "Settings": "What do you want to do?"
+        }
+      },
+      "configure": {
+        "title": "Configure options",
         "data": {
           "scan_interval": "Seconds between updates (media player only)",
           "alarm_home_mode": "Alarm arm home mode name",


### PR DESCRIPTION
**What this adds**

- **See how Control4 rooms map to Home Assistant** — From the integration options you can open a table of all entities with their C4 room/floor and current HA area/floor, so you can spot mismatches before changing anything.

- **One-click sync of C4 structure into Home Assistant** — Option to create missing HA areas and floors from C4 and assign devices to the right areas. Handles existing areas (reuses them instead of failing) and tells you what was skipped or still doesn't match.

- **Download the full director snapshot as JSON** — Option to get a "Download JSON file" link that opens or saves the full director payload. Useful for debugging, backups, or feeding into other tools without touching the director API yourself.

**Why it's useful**

- Keeps HA areas/floors aligned with how your system is set up in Composer.
- New HA version with its new Dashboard UI, relies heavily on device location 
- Reduces manual area/floor creation and device assignment in HA.
- Gives a simple way to export director data for support or automation.

**Where to find it**

Integration → Control4 → Configure → **Configure options…** → choose "Show c4 device area/floor", "Apply c4 device area/floor to HA", or "Download JSON file".