### PR TITLE
Add Dynalite gateway events for Control4 trigger sensors in Home Assistant

### DIFF
--- a/custom_components/control4/__init__.py
+++ b/custom_components/control4/__init__.py
@@ -47,6 +47,7 @@ from .const import (
     CONF_CONTROLLER_UNIQUE_ID,
     CONF_DIRECTOR,
     CONF_DIRECTOR_ALL_ITEMS,
+    CONF_DYNALITE_ENABLED,
     CONF_DIRECTOR_MODEL,
     CONF_DIRECTOR_SW_VERSION,
     CONF_WEBSOCKET,
@@ -61,9 +62,24 @@ from .const import (
     RETRY_BACKOFF_MAX_SEC,
     SCHEDULE_REFRESH_ADVANCE_SEC,
 )
-from .director_utils import director_get_entry_variables
+from .config_flow import Control4ExportView
+from .director_utils import (
+    director_get_entry_variables,
+    director_has_dynalite_triggers,
+)
+from . import dynalite as dynalite_module
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Register the export view when the integration is loaded (so the route exists before entries)."""
+    hass.data.setdefault(DOMAIN, {})
+    if "_export_view_registered" not in hass.data[DOMAIN]:
+        hass.http.register_view(Control4ExportView())
+        hass.data[DOMAIN]["_export_view_registered"] = True
+    return True
+
 
 PLATFORMS = [
     Platform.LIGHT,
@@ -81,6 +97,9 @@ PLATFORMS = [
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Control4 from a config entry."""
     hass.data.setdefault(DOMAIN, {})
+    if "_export_view_registered" not in hass.data[DOMAIN]:
+        hass.http.register_view(Control4ExportView())
+        hass.data[DOMAIN]["_export_view_registered"] = True
     entry_data = hass.data[DOMAIN].setdefault(entry.entry_id, {})
     config = entry.data
 
@@ -156,6 +175,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DEFAULT_ALARM_VACATION_MODE,
     }
 
+    # Dynalite gateway listener (TCP) for trigger binary sensors — only when enabled
+    # and Director data includes at least one dynalite_trigger
+    entry_data[CONF_DYNALITE_ENABLED] = entry.options.get(CONF_DYNALITE_ENABLED, False)
+    if entry_data[CONF_DYNALITE_ENABLED]:
+        if director_has_dynalite_triggers(entry_data):
+            await dynalite_module.setup_dynalite_listener(hass, entry, entry_data)
+        else:
+            _LOGGER.info(
+                "Dynalite TCP listener not started: no dynalite_trigger devices in Director data"
+            )
+
     entry_data[CONF_CONFIG_LISTENER] = entry.add_update_listener(update_listener)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -168,6 +198,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     entry_data = hass.data[DOMAIN][entry.entry_id]
+    if entry_data.get(CONF_DYNALITE_ENABLED):
+        dynalite_module.stop_dynalite_listener(hass, entry.entry_id)
     _LOGGER.debug("Disconnecting C4Websocket for config entry unload")
     await entry_data[CONF_WEBSOCKET].sio_disconnect()
     _LOGGER.debug("Cancelling scheduled token refresh for config entry unload")
@@ -193,12 +225,11 @@ async def get_items_of_category(hass: HomeAssistant, entry: ConfigEntry, categor
     try:
         return_list = await director.get_all_items_by_category(category)
         return return_list
-    except InvalidCategory as e:
+    except InvalidCategory:
         _LOGGER.warning(
-            "Category %s does not exist on this Control4 system, \
-                        entities from this domain will not be setup.",
+            "Category %s does not exist on this Control4 system, "
+            "entities from this domain will not be setup.",
             category,
-            exc_info=True,
         )
         return []
 

--- a/custom_components/control4/binary_sensor.py
+++ b/custom_components/control4/binary_sensor.py
@@ -1,6 +1,7 @@
 """Platform for Control4 Binary Sensor."""
 from __future__ import annotations
 
+from datetime import datetime
 from functools import cached_property
 import logging
 
@@ -10,9 +11,17 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_call_later
 
 from . import Control4Entity, get_items_of_category
-from .const import CONF_DIRECTOR, CONF_DIRECTOR_ALL_ITEMS, CONTROL4_ENTITY_TYPE, DOMAIN
+from .const import (
+    CONF_DIRECTOR,
+    CONF_DIRECTOR_ALL_ITEMS,
+    CONF_DYNALITE_ENABLED,
+    CONF_CONTROLLER_UNIQUE_ID,
+    CONTROL4_ENTITY_TYPE,
+    DOMAIN,
+)
 from .director_utils import director_get_entry_variables
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,6 +49,9 @@ CONTROL4_PROXY_MAPPING = {
     CONTROL4_MOTION_PROXY: BinarySensorDeviceClass.MOTION,
     CONTROL4_GARAGE_DOOR_PROXY: BinarySensorDeviceClass.GARAGE_DOOR,
 }
+
+DYNALITE_TRIGGER_PROXY = "dynalite_trigger"
+TRIGGER_RESET_SEC = 2
 
 
 async def async_setup_entry(
@@ -151,6 +163,39 @@ async def async_setup_entry(
                 unique_id,
             )
         )
+
+    # Dynalite trigger binary sensors (updated by TCP listener when enabled)
+    if entry_data.get(CONF_DYNALITE_ENABLED):
+        for item in director_all_items:
+            if (
+                item.get("type") == CONTROL4_ENTITY_TYPE
+                and item.get("id")
+                and item.get("proxy") == DYNALITE_TRIGGER_PROXY
+            ):
+                item_id = item["id"]
+                item_name = str(item.get("name", f"Dynalite {item_id}"))
+                item_area = item.get("roomName", "")
+                item_parent_id = item.get("parentId")
+                item_device_name = None
+                item_manufacturer = item.get("manufacturer")
+                item_model = item.get("model")
+                for parent_item in director_all_items:
+                    if parent_item.get("id") == item_parent_id:
+                        item_device_name = parent_item.get("name")
+                        break
+                entity_list.append(
+                    Control4DynaliteTriggerBinarySensor(
+                        entry_data=entry_data,
+                        entry=entry,
+                        name=item_name,
+                        idx=item_id,
+                        device_name=item_device_name,
+                        device_manufacturer=item_manufacturer,
+                        device_model=item_model,
+                        device_id=item_parent_id or 0,
+                        device_area=item_area,
+                    )
+                )
 
     async_add_entities(entity_list, True)
 
@@ -278,3 +323,83 @@ class Control4BinarySensor(Control4Entity, BinarySensorEntity):  # type: ignore[
         # Rather, they are attached to a room id.
         # Therefore, there is no device info for Home Assistant to use.
         return None
+
+
+class Control4DynaliteTriggerBinarySensor(BinarySensorEntity):
+    """Binary sensor for Dynalite triggers; state is set by the Dynalite TCP listener."""
+
+    _attr_should_poll = False
+    _attr_device_class = BinarySensorDeviceClass.OCCUPANCY
+
+    def __init__(
+        self,
+        entry_data: dict,
+        entry: ConfigEntry,
+        name: str,
+        idx: int,
+        device_name: str | None,
+        device_manufacturer: str | None,
+        device_model: str | None,
+        device_id: int,
+        device_area: str,
+    ) -> None:
+        """Initialize Dynalite trigger binary sensor."""
+        self.entry_data = entry_data
+        self.entry = entry
+        self._attr_name = name
+        self._attr_unique_id = f"{entry.entry_id}_dynalite_{idx}"
+        self._idx = idx
+        self._attr_is_on = False
+        self._device_name = device_name
+        self._device_manufacturer = device_manufacturer
+        self._device_model = device_model
+        self._device_id = device_id
+        self._device_area = device_area
+        self._reset_call = None
+
+    async def async_added_to_hass(self) -> None:
+        """Register this entity so the Dynalite listener can update it."""
+        await super().async_added_to_hass()
+        self.entry_data.setdefault("dynalite_entities", {})[self._idx] = self
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister from dynalite_entities."""
+        if self._reset_call:
+            self._reset_call()
+            self._reset_call = None
+        self.entry_data.get("dynalite_entities", {}).pop(self._idx, None)
+        await super().async_will_remove_from_hass()
+
+    def set_triggered(self) -> None:
+        """Set state to on (triggered) and schedule reset to off after TRIGGER_RESET_SEC."""
+        _LOGGER.debug(
+            "Dynalite binary sensor triggered: item_id=%s entity_id=%s",
+            self._idx,
+            getattr(self, "entity_id", None),
+        )
+        if self._reset_call:
+            self._reset_call()
+            self._reset_call = None
+        self._attr_is_on = True
+        self.hass.add_job(self.async_write_ha_state)
+        self._reset_call = async_call_later(
+            self.hass,
+            TRIGGER_RESET_SEC,
+            self._async_reset_off,
+        )
+
+    async def _async_reset_off(self, _now: datetime) -> None:
+        """Reset state to off on the event loop (async_call_later may not run sync callbacks on loop)."""
+        self._reset_call = None
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self):
+        """Return device info linking to the Control4 controller."""
+        return {
+            "identifiers": {(DOMAIN, self.entry_data[CONF_CONTROLLER_UNIQUE_ID])},
+            "name": self._device_name or "Control4",
+            "manufacturer": self._device_manufacturer or "Control4",
+            "model": self._device_model,
+        }

--- a/custom_components/control4/config_flow.py
+++ b/custom_components/control4/config_flow.py
@@ -1,7 +1,13 @@
 """Config flow for Control4 integration."""
-from asyncio import TimeoutError as asyncioTimeoutError
-import logging
+from __future__ import annotations
 
+import asyncio
+import json
+import logging
+from asyncio import TimeoutError as asyncioTimeoutError
+from typing import Any
+
+from aiohttp import web
 from aiohttp.client_exceptions import ClientError
 from pyControl4.account import C4Account
 from pyControl4.director import C4Director
@@ -9,15 +15,22 @@ from pyControl4.error_handling import NotFound, Unauthorized
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
+from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
     CONF_USERNAME,
     CONF_SCAN_INTERVAL,
 )
-from homeassistant.core import callback
-from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import (
+    aiohttp_client,
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.network import get_url
 
 from .const import (
     CONF_ALARM_ARM_STATES,
@@ -27,17 +40,162 @@ from .const import (
     CONF_ALARM_NIGHT_MODE,
     CONF_ALARM_VACATION_MODE,
     CONF_CONTROLLER_UNIQUE_ID,
+    CONF_DIRECTOR_ALL_ITEMS,
+    CONF_DYNALITE_ENABLED,
+    CONF_DYNALITE_HOST,
+    CONF_DYNALITE_PARSE_LAYOUT,
+    CONF_DYNALITE_PORT,
+    DEFAULT_DYNALITE_PARSE_LAYOUT,
+    DYNALITE_PARSE_LAYOUT_BYTES_2_3,
+    DYNALITE_PARSE_LAYOUT_DYNET,
+    CONTROL4_ENTITY_TYPE,
     DEFAULT_ALARM_AWAY_MODE,
     DEFAULT_ALARM_CUSTOM_BYPASS_MODE,
     DEFAULT_ALARM_HOME_MODE,
     DEFAULT_ALARM_NIGHT_MODE,
     DEFAULT_ALARM_VACATION_MODE,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_DYNALITE_PORT,
     DOMAIN,
     MIN_SCAN_INTERVAL,
 )
+from .director_utils import (
+    director_get_entry_variables,
+    director_get_item_properties,
+    director_has_dynalite_triggers,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def build_control4_export_payload(
+    hass: HomeAssistant, entry_id: str
+) -> dict[str, Any] | None:
+    """Build export payload (meta + items with variables) for the given config entry."""
+    entry_data = (hass.data.get(DOMAIN) or {}).get(entry_id)
+    if not entry_data:
+        return None
+    data = entry_data.get(CONF_DIRECTOR_ALL_ITEMS)
+    if not data:
+        return None
+    entry = next(
+        (e for e in hass.config_entries.async_entries(DOMAIN) if e.entry_id == entry_id),
+        None,
+    )
+    if not entry:
+        return None
+
+    export_list = [dict(item) for item in data]
+    device_indices = [
+        i
+        for i, item in enumerate(export_list)
+        if item.get("type") == CONTROL4_ENTITY_TYPE and item.get("id")
+    ]
+
+    async def fetch_vars(index: int) -> tuple[int, dict[str, Any]]:
+        item = export_list[index]
+        item_id = item["id"]
+        try:
+            variables = await director_get_entry_variables(hass, entry, item_id)
+            return (index, variables)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Export: failed to get variables for item %s: %s", item_id, err)
+            return (index, {"_error": str(err)})
+
+    batch_size = 20
+    for start in range(0, len(device_indices), batch_size):
+        batch = device_indices[start : start + batch_size]
+        results = await asyncio.gather(*(fetch_vars(i) for i in batch))
+        for index, variables in results:
+            export_list[index]["variables"] = variables
+
+    # Items that should get Director properties (e.g. area/channel for Dynalite)
+    def item_wants_properties(item: dict[str, Any]) -> bool:
+        if item.get("proxy") == "dynalite_trigger":
+            return True
+        links = item.get("links") or []
+        return any(
+            "/properties" in (link.get("href") or "")
+            for link in links
+            if isinstance(link, dict)
+        )
+
+    properties_indices = [
+        i
+        for i, item in enumerate(export_list)
+        if item.get("id") is not None and item_wants_properties(item)
+    ]
+
+    async def fetch_props(index: int) -> tuple[int, dict[str, Any] | None]:
+        item = export_list[index]
+        item_id = item["id"]
+        props = await director_get_item_properties(hass, entry, item_id)
+        return (index, props)
+
+    for start in range(0, len(properties_indices), batch_size):
+        batch = properties_indices[start : start + batch_size]
+        results = await asyncio.gather(*(fetch_props(i) for i in batch))
+        for index, props in results:
+            export_list[index]["properties"] = props
+
+    dev_reg = dr.async_get(hass)
+    ha_device_count = sum(
+        1 for d in dev_reg.devices.values() if entry.entry_id in d.config_entries
+    )
+    entity_reg = er.async_get(hass)
+    ha_entities: dict[str, int] = {}
+    for entity in entity_reg.entities.values():
+        if entity.config_entry_id != entry.entry_id:
+            continue
+        platform = entity.platform or "unknown"
+        ha_entities[platform] = ha_entities.get(platform, 0) + 1
+
+    return {
+        "meta": {"ha_device_count": ha_device_count, "ha_entities": ha_entities},
+        "items": export_list,
+    }
+
+
+class Control4ExportView(HomeAssistantView):
+    """HTTP view to serve director_all_items as JSON for browser download (Save As)."""
+
+    requires_auth = False
+    url = "/api/control4/export"
+    name = "api:control4:export"
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Serve pretty-printed JSON; uses build_control4_export_payload on demand."""
+        hass = request.app["hass"]
+        entry_id = request.query.get("entry_id")
+        if not entry_id:
+            return web.Response(
+                status=400,
+                text="entry_id query parameter required",
+                content_type="text/plain",
+            )
+        payload = await build_control4_export_payload(hass, entry_id)
+        if not payload:
+            # 503 so the link is valid but data wasn't ready (e.g. integration still loading)
+            msg = (
+                "Entry not found or export data not available. "
+                "If you just reloaded, wait for the Control4 integration to finish loading and try again."
+            )
+            _LOGGER.warning("Export failed for entry_id=%s: %s", entry_id, msg)
+            return web.Response(
+                status=503,
+                text=msg,
+                content_type="text/plain",
+            )
+        try:
+            body = json.dumps(payload, indent=2, ensure_ascii=False, default=str)
+        except (TypeError, ValueError) as err:
+            _LOGGER.exception("Export serialize error: %s", err)
+            return web.Response(status=500, text=f"Serialize error: {err}")
+        return web.Response(
+            body=body,
+            content_type="application/json",
+            headers={"Content-Disposition": 'attachment; filename="control4_export.json"'},
+        )
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -200,11 +358,93 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         # Do not assign to self.config_entry; it's a read-only property in HA.
         self._config_entry = config_entry
 
+    def _entry_data_ready(self):
+        """Return True if integration entry data is loaded (e.g. JSON download)."""
+        entry_data = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
+        return bool(entry_data and entry_data.get(CONF_DIRECTOR_ALL_ITEMS))
+
+    async def _notify_and_close(self, title: str, message: str, notification_id: str):
+        """Send a persistent notification and close the options flow."""
+        await self.hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {
+                "title": title,
+                "message": message,
+                "notification_id": notification_id,
+            },
+        )
+        return self.async_create_entry(title="", data=self._config_entry.options)
+
+    async def _handle_download(self):
+        """Notify with a link that triggers browser Save As when opened."""
+        base = get_url(self.hass)
+        path = f"/api/control4/export?entry_id={self._config_entry.entry_id}"
+        if base:
+            url = base.rstrip("/") + path
+            msg = f"Open this link in your browser to download the JSON file (Save As):\n\n{url}"
+        else:
+            msg = (
+                "Could not determine HA URL. Set it in Settings → Home Assistant URL (Local Network), "
+                f"or open this path in your browser (prepend your HA address):\n\n{path}"
+            )
+        return await self._notify_and_close(
+            "Control4 download JSON",
+            msg,
+            "control4_download_json",
+        )
+
     async def async_step_init(self, user_input=None):
-        """Handle options flow."""
+        """Handle options flow: menu to choose configure or show table."""
+        if user_input is not None:
+            if user_input.get("Settings") == "download":
+                if not self._entry_data_ready():
+                    return await self._notify_and_close(
+                        "Control4 download JSON",
+                        "Integration data is not ready. Please try again after the integration has finished loading.",
+                        "control4_download_json",
+                    )
+                return await self._handle_download()
+            return await self.async_step_configure()
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("Settings", default="configure"): vol.In(
+                        {
+                            "configure": "Configure options (scan interval, alarm, Dynalite)",
+                            "download": "Download JSON file",
+                        }
+                    ),
+                }
+            ),
+            description_placeholders={"heading": "Control4 settings"},
+        )
+
+    async def async_step_configure(self, user_input=None):
+        """Handle the configure-options form (scan interval, alarm modes, Dynalite TCP)."""
         if user_input is not None:
             _LOGGER.debug(user_input)
-            return self.async_create_entry(title="", data=user_input)
+            entry_data_submit = (
+                (self.hass.data.get(DOMAIN) or {}).get(self._config_entry.entry_id)
+                or {}
+            )
+            has_dynalite = director_has_dynalite_triggers(entry_data_submit)
+            enabled = bool(user_input.get(CONF_DYNALITE_ENABLED, False)) and has_dynalite
+            if not enabled:
+                data = {
+                    **user_input,
+                    CONF_DYNALITE_ENABLED: False,
+                    CONF_DYNALITE_HOST: "",
+                    CONF_DYNALITE_PORT: DEFAULT_DYNALITE_PORT,
+                    CONF_DYNALITE_PARSE_LAYOUT: self._config_entry.options.get(
+                        CONF_DYNALITE_PARSE_LAYOUT, DEFAULT_DYNALITE_PARSE_LAYOUT
+                    ),
+                }
+                return self.async_create_entry(title="", data=data)
+            self._configure_base = user_input
+            return await self.async_step_configure_dynalite_tcp()
 
         # TODO: figure out how to accept empty strings to disable modes
         # TODO: figure out how to only show alarm options if a alarm_control_panel entity exists
@@ -214,22 +454,23 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         arm_state_choices = set(self.entry_data.get(CONF_ALARM_ARM_STATES, [])) or {
             DEFAULT_ALARM_AWAY_MODE
         }
-
         # Determine if a security panel is effectively present (has real arm states)
         has_security = any(
             x.strip() and x.strip() != DEFAULT_ALARM_AWAY_MODE for x in arm_state_choices
         )
 
-        # Always include scan interval; include alarm options only if we have a panel
+        # Base schema: scan interval; alarm options only if we have a panel
+        schema_dict = {
+            vol.Optional(
+                CONF_SCAN_INTERVAL,
+                default=self._config_entry.options.get(
+                    CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                ),
+            ): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL)),
+        }
         if has_security:
-            data_schema = vol.Schema(
+            schema_dict.update(
                 {
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL,
-                        default=self._config_entry.options.get(
-                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-                        ),
-                    ): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL)),
                     vol.Optional(
                         CONF_ALARM_AWAY_MODE,
                         default=self._config_entry.options.get(
@@ -260,22 +501,82 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_ALARM_VACATION_MODE, DEFAULT_ALARM_VACATION_MODE
                         ),
                     ): vol.In(sorted(arm_state_choices)),
-                },
-                required=False,
+                }
             )
-        else:
-            data_schema = vol.Schema(
+        # Dynalite: TCP only; show enable toggle only when project has dynalite_trigger devices
+        has_dynalite = director_has_dynalite_triggers(self.entry_data)
+        desc: dict[str, str] = {}
+        if has_dynalite:
+            schema_dict.update(
                 {
                     vol.Optional(
-                        CONF_SCAN_INTERVAL,
+                        CONF_DYNALITE_ENABLED,
                         default=self._config_entry.options.get(
-                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                            CONF_DYNALITE_ENABLED, False
                         ),
-                    ): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL)),
-                },
-                required=False,
+                        description="Enable Dynalite gateway listener (TCP)",
+                    ): bool,
+                }
             )
-        return self.async_show_form(step_id="init", data_schema=data_schema)
+            desc[CONF_DYNALITE_ENABLED] = (
+                "Listen to the Dynalite gateway via TCP for trigger events (binary sensors)."
+            )
+        schema = vol.Schema(schema_dict, required=False)
+        try:
+            return self.async_show_form(
+                step_id="configure",
+                data_schema=schema,
+                data_description=desc,
+            )
+        except TypeError:
+            return self.async_show_form(step_id="configure", data_schema=schema)
+
+    async def async_step_configure_dynalite_tcp(self, user_input=None):
+        """Collect TCP host/port and frame layout for Dynalite gateway."""
+        if user_input is not None:
+            merged = {
+                **self._configure_base,
+                CONF_DYNALITE_HOST: (user_input.get(CONF_DYNALITE_HOST) or "").strip(),
+                CONF_DYNALITE_PORT: user_input.get(
+                    CONF_DYNALITE_PORT, DEFAULT_DYNALITE_PORT
+                ),
+                CONF_DYNALITE_PARSE_LAYOUT: user_input.get(
+                    CONF_DYNALITE_PARSE_LAYOUT, DEFAULT_DYNALITE_PARSE_LAYOUT
+                ),
+            }
+            return self.async_create_entry(title="", data=merged)
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_DYNALITE_HOST,
+                    default=self._config_entry.options.get(CONF_DYNALITE_HOST, ""),
+                    description="Dynalite gateway IP",
+                ): str,
+                vol.Optional(
+                    CONF_DYNALITE_PORT,
+                    default=self._config_entry.options.get(
+                        CONF_DYNALITE_PORT, DEFAULT_DYNALITE_PORT
+                    ),
+                    description="Dynalite gateway port",
+                ): cv.port,
+                vol.Optional(
+                    CONF_DYNALITE_PARSE_LAYOUT,
+                    default=self._config_entry.options.get(
+                        CONF_DYNALITE_PARSE_LAYOUT, DEFAULT_DYNALITE_PARSE_LAYOUT
+                    ),
+                    description="TCP frame layout",
+                ): vol.In(
+                    {
+                        DYNALITE_PARSE_LAYOUT_DYNET: "DyNet (standard bus)",
+                        DYNALITE_PARSE_LAYOUT_BYTES_2_3: "Bytes 2–3 (legacy)",
+                    }
+                ),
+            }
+        )
+        return self.async_show_form(
+            step_id="configure_dynalite_tcp",
+            data_schema=schema,
+        )
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/custom_components/control4/const.py
+++ b/custom_components/control4/const.py
@@ -31,5 +31,16 @@ CONF_CONFIG_LISTENER = "config_listener"
 
 CONTROL4_ENTITY_TYPE = 7
 
+# Dynalite gateway listener (TCP only)
+CONF_DYNALITE_ENABLED = "dynalite_enabled"
+CONF_DYNALITE_HOST = "dynalite_host"
+CONF_DYNALITE_PORT = "dynalite_port"
+CONF_DYNALITE_PARSE_LAYOUT = "dynalite_parse_layout"
+DEFAULT_DYNALITE_PORT = 10001
+# Frame layout: "bytes_2_3" = area at byte 2, channel at byte 3; "dynet" = area at byte 1, channel at byte 3 (DyNet standard)
+DYNALITE_PARSE_LAYOUT_BYTES_2_3 = "bytes_2_3"
+DYNALITE_PARSE_LAYOUT_DYNET = "dynet"
+DEFAULT_DYNALITE_PARSE_LAYOUT = DYNALITE_PARSE_LAYOUT_DYNET
+
 RETRY_BACKOFF_MAX_SEC = 30
 SCHEDULE_REFRESH_ADVANCE_SEC = 300

--- a/custom_components/control4/director_utils.py
+++ b/custom_components/control4/director_utils.py
@@ -1,11 +1,29 @@
 """Provides data updates from the Control4 controller for platforms."""
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from typing import Any
+import logging
 from collections import defaultdict
 from collections.abc import Set
+from typing import Any
 
-from .const import CONF_DIRECTOR, DOMAIN
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+
+from .const import CONF_DIRECTOR, CONF_DIRECTOR_ALL_ITEMS, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DYNALITE_TRIGGER_PROXY = "dynalite_trigger"
+
+
+def director_has_dynalite_triggers(entry_data: dict[str, Any] | None) -> bool:
+    """True if Director inventory includes at least one dynalite_trigger with an id."""
+    if not entry_data:
+        return False
+    all_items = entry_data.get(CONF_DIRECTOR_ALL_ITEMS) or []
+    return any(
+        item.get("proxy") == DYNALITE_TRIGGER_PROXY and item.get("id")
+        for item in all_items
+    )
 
 
 async def director_get_entry_variables(
@@ -31,3 +49,35 @@ async def update_variables_for_config_entry(
     for item in data:
         result_dict[item["id"]][item["varName"]] = item["value"]
     return dict(result_dict)
+
+
+async def director_get_item_properties(
+    hass: HomeAssistant, entry: ConfigEntry, item_id: int
+) -> dict[str, Any] | None:
+    """Retrieve Director properties for a Control4 item (e.g. area/channel for Dynalite)."""
+    entry_data = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
+    if not entry_data:
+        return None
+    director = entry_data.get(CONF_DIRECTOR)
+    if not director:
+        return None
+    url = f"{director.base_url}/api/v1/items/{item_id}/properties"
+    session = aiohttp_client.async_get_clientsession(hass, verify_ssl=False)
+    headers = {"Authorization": f"Bearer {director.director_bearer_token}"}
+    try:
+        async with session.get(url, headers=headers) as resp:
+            if resp.status == 200:
+                return await resp.json()
+            _LOGGER.debug(
+                "Export: properties for item %s returned status %s",
+                item_id,
+                resp.status,
+            )
+            return None
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug(
+            "Export: failed to get properties for item %s: %s",
+            item_id,
+            err,
+        )
+        return None

--- a/custom_components/control4/dynalite.py
+++ b/custom_components/control4/dynalite.py
@@ -1,0 +1,396 @@
+"""Dynalite gateway event listener (TCP) for Control4 Dynalite trigger binary sensors."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_DIRECTOR_ALL_ITEMS,
+    CONF_DYNALITE_ENABLED,
+    CONF_DYNALITE_HOST,
+    CONF_DYNALITE_PARSE_LAYOUT,
+    CONF_DYNALITE_PORT,
+    DEFAULT_DYNALITE_PARSE_LAYOUT,
+    DEFAULT_DYNALITE_PORT,
+    DOMAIN,
+    DYNALITE_PARSE_LAYOUT_DYNET,
+)
+from .director_utils import director_get_item_properties
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def build_dynalite_event_map(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[tuple[int, int], int]:
+    """Build (area, channel) -> C4 item_id from Director dynalite_trigger items and their properties."""
+    result: dict[tuple[int, int], int] = {}
+    entry_data = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
+    if not entry_data:
+        return result
+    all_items = entry_data.get(CONF_DIRECTOR_ALL_ITEMS) or []
+    for item in all_items:
+        if item.get("proxy") != "dynalite_trigger" or not item.get("id"):
+            continue
+        item_id = item["id"]
+        props = await director_get_item_properties(hass, entry, item_id)
+        if not props or not isinstance(props, list):
+            continue
+        area_val: int | None = None
+        channel_val: int = 0
+        for prop in props:
+            if not isinstance(prop, dict):
+                continue
+            name = prop.get("name")
+            val = prop.get("value")
+            if name == "Area" and val is not None:
+                try:
+                    area_val = int(val) if not isinstance(val, int) else val
+                except (TypeError, ValueError):
+                    pass
+            if name == "Channel" and val is not None:
+                try:
+                    channel_val = int(val) if not isinstance(val, int) else val
+                except (TypeError, ValueError):
+                    pass
+        if area_val is not None:
+            key = (area_val, channel_val)
+            result[key] = item_id
+            name = item.get("name", "")
+            _LOGGER.info(
+                "Dynalite trigger captured: item_id=%s (C4 Director ID, same as in JSON export) name='%s' area=%s channel=%s",
+                item_id,
+                name,
+                area_val,
+                channel_val,
+            )
+    return result
+
+
+async def setup_dynalite_listener(
+    hass: HomeAssistant, entry: ConfigEntry, entry_data: dict[str, Any]
+) -> None:
+    """Load Dynalite options, build event map, register callback, and start TCP listener.
+    Call only when CONF_DYNALITE_ENABLED is True. Mutates entry_data.
+    """
+    entry_data[CONF_DYNALITE_PARSE_LAYOUT] = entry.options.get(
+        CONF_DYNALITE_PARSE_LAYOUT, DEFAULT_DYNALITE_PARSE_LAYOUT
+    )
+    entry_data[CONF_DYNALITE_HOST] = (entry.options.get(CONF_DYNALITE_HOST) or "").strip()
+    entry_data[CONF_DYNALITE_PORT] = entry.options.get(
+        CONF_DYNALITE_PORT, DEFAULT_DYNALITE_PORT
+    )
+    entry_data["dynalite_event_map"] = await build_dynalite_event_map(hass, entry)
+    event_map = entry_data["dynalite_event_map"]
+    # Human-readable summary: full data for all triggers (same as in Control4 export JSON)
+    all_items = entry_data.get(CONF_DIRECTOR_ALL_ITEMS) or []
+    id_to_name = {item["id"]: item.get("name", "") for item in all_items if item.get("id")}
+    id_to_room = {item["id"]: item.get("roomName", "") for item in all_items if item.get("id")}
+    map_entries = sorted(event_map.items(), key=lambda x: (x[0][0], x[0][1]))
+    _LOGGER.info(
+        "Dynalite triggers: %s sensors (same id/name/area/channel as in Download JSON export). Full data:",
+        len(event_map),
+    )
+    for (area, ch), iid in map_entries:
+        _LOGGER.info(
+            "  item_id=%s name='%s' area=%s channel=%s room='%s'",
+            iid,
+            id_to_name.get(iid, ""),
+            area,
+            ch,
+            id_to_room.get(iid, ""),
+        )
+    entry_data["dynalite_entities"] = {}
+    entry_data["_dynalite_logged_no_mapping"] = set()
+    # Collect examples of (area, channel) received from TCP for one-time summary
+    entry_data["_dynalite_received_keys"] = set()
+    entry_data["_dynalite_received_keys_logged"] = False
+
+    def _on_dynalite_event(area: int, channel: int, value: int) -> None:
+        _LOGGER.debug("Dynalite event received: area=%s channel=%s value=%s", area, channel, value)
+        ed = (hass.data.get(DOMAIN) or {}).get(entry.entry_id)
+        if not ed:
+            _LOGGER.debug("Dynalite event: no entry_data for entry_id=%s", entry.entry_id)
+            return
+        # Log once: examples of (area, channel) keys we receive from TCP
+        received = ed.get("_dynalite_received_keys")
+        if received is not None and not ed.get("_dynalite_received_keys_logged"):
+            received.add((area, channel))
+            if len(received) >= 5:
+                ed["_dynalite_received_keys_logged"] = True
+                examples = sorted(received, key=lambda x: (x[0], x[1]))
+                _LOGGER.info(
+                    "Dynalite TCP listener: examples of (area, channel) received from gateway: %s",
+                    examples,
+                )
+        event_map = ed.get("dynalite_event_map") or {}
+        item_id = event_map.get((area, channel)) or event_map.get((area, 0))
+        if item_id is None:
+            key = (area, channel)
+            logged = ed.get("_dynalite_logged_no_mapping")
+            if logged is not None and key not in logged:
+                logged.add(key)
+                _LOGGER.info(
+                    "Dynalite event has no trigger: area=%s channel=%s (configured triggers use areas %s; press a button bound to a dynalite_trigger in Composer)",
+                    area,
+                    channel,
+                    sorted({k[0] for k in event_map.keys()}),
+                )
+            else:
+                _LOGGER.debug(
+                    "Dynalite event: no mapping for area=%s channel=%s",
+                    area,
+                    channel,
+                )
+            return
+        entities = ed.get("dynalite_entities") or {}
+        entity = entities.get(item_id)
+        if entity is None:
+            _LOGGER.debug(
+                "Dynalite event: entity not yet registered for item_id=%s (area=%s channel=%s)",
+                item_id,
+                area,
+                channel,
+            )
+            return
+        if hasattr(entity, "set_triggered"):
+            _LOGGER.info(
+                "Dynalite event matched sensor: item_id=%s area=%s channel=%s name='%s'",
+                item_id,
+                area,
+                channel,
+                getattr(entity, "name", "") or "",
+            )
+            _LOGGER.debug("Dynalite trigger firing for item_id=%s", item_id)
+            entity.set_triggered()
+        else:
+            _LOGGER.debug("Dynalite event: entity %s has no set_triggered", item_id)
+
+    register_dynalite_callback(hass, entry.entry_id, _on_dynalite_event)
+    config = {
+        CONF_DYNALITE_ENABLED: True,
+        CONF_DYNALITE_PARSE_LAYOUT: entry_data.get(
+            CONF_DYNALITE_PARSE_LAYOUT, DEFAULT_DYNALITE_PARSE_LAYOUT
+        ),
+        CONF_DYNALITE_HOST: entry_data[CONF_DYNALITE_HOST],
+        CONF_DYNALITE_PORT: entry_data[CONF_DYNALITE_PORT],
+    }
+    start_dynalite_listener(hass, entry, config)
+
+
+# 8-byte ACK/heartbeat from gateway (ASCII "lCooMasR")
+DYNALITE_ACK = bytes([0x6C, 0x43, 0x6F, 0x6F, 0x4D, 0x61, 0x73, 0x52])
+FRAME_LEN = 8
+DYNET_CMD = 0x1C
+
+
+def parse_frame(
+    data: bytes,
+    layout: str = DEFAULT_DYNALITE_PARSE_LAYOUT,
+) -> tuple[int, int, int] | None:
+    """Parse 8-byte DyNet-style frame. Returns (area, channel, value) or None if skip.
+
+    layout "bytes_2_3": area=data[2], channel=data[3] (original).
+    layout "dynet": area=data[1], channel=data[3] (DyNet standard; byte 3 is opcode).
+    """
+    if len(data) != FRAME_LEN:
+        _LOGGER.debug(
+            "Dynalite frame skip: length %s (expected %s) raw=%s",
+            len(data),
+            FRAME_LEN,
+            data.hex() if data else "(empty)",
+        )
+        return None
+    if data == DYNALITE_ACK:
+        _LOGGER.debug("Dynalite frame skip: ACK/heartbeat")
+        return None
+    if data[0] != DYNET_CMD:
+        _LOGGER.debug(
+            "Dynalite frame skip: cmd 0x%02x (expected 0x1C) raw=%s (enable debug and trigger motion to see if gateway uses this format)",
+            data[0],
+            data.hex(),
+        )
+        return None
+    if layout == DYNALITE_PARSE_LAYOUT_DYNET:
+        area = data[1]
+        channel = data[3]  # opcode in DyNet; use as channel for (area, channel) matching
+    else:
+        area = data[2]
+        channel = data[3]
+    v1, v2 = data[4], data[5]
+    if v1 != 0xFF and v2 != 0xFF:
+        value = v1
+    else:
+        value = 0  # preset/trigger, no numeric value
+    _LOGGER.debug(
+        "Dynalite frame parsed (layout=%s): area=%s channel=%s value=%s raw=%s",
+        layout,
+        area,
+        channel,
+        value,
+        data.hex(),
+    )
+    return (area, channel, value)
+
+
+def register_dynalite_callback(
+    hass: HomeAssistant,
+    entry_id: str,
+    callback: Callable[[int, int, int], None],
+) -> None:
+    """Register a callback for Dynalite events (area, channel, value)."""
+    hass.data.setdefault(DOMAIN, {})
+    entry_data = hass.data[DOMAIN].setdefault(entry_id, {})
+    entry_data["dynalite_on_event"] = callback
+
+
+def _get_callback(hass: HomeAssistant, entry_id: str) -> Callable[[int, int, int], None] | None:
+    entry_data = (hass.data.get(DOMAIN) or {}).get(entry_id)
+    if not entry_data:
+        return None
+    return entry_data.get("dynalite_on_event")
+
+
+def _invoke_callback(hass: HomeAssistant, entry_id: str, area: int, channel: int, value: int) -> None:
+    cb = _get_callback(hass, entry_id)
+    if cb:
+        try:
+            cb(area, channel, value)
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Dynalite event callback error for area=%s ch=%s", area, channel)
+
+
+async def _run_tcp_listener(
+    hass: HomeAssistant,
+    entry_id: str,
+    host: str,
+    port: int,
+    shutdown: asyncio.Event,
+    parse_layout: str = DEFAULT_DYNALITE_PARSE_LAYOUT,
+) -> None:
+    backoff = 1.0
+    max_backoff = 60.0
+    while not shutdown.is_set():
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(host, port),
+                timeout=10.0,
+            )
+        except asyncio.CancelledError:
+            break
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning(
+                "Dynalite TCP connect to %s:%s failed: %s; retry in %.0fs",
+                host,
+                port,
+                err,
+                backoff,
+            )
+            try:
+                await asyncio.wait_for(shutdown.wait(), timeout=backoff)
+            except asyncio.TimeoutError:
+                pass
+            backoff = min(backoff * 2, max_backoff)
+            continue
+        backoff = 1.0
+        _LOGGER.info("Dynalite TCP connected to %s:%s", host, port)
+        buf = b""
+        try:
+            while not shutdown.is_set():
+                try:
+                    data = await asyncio.wait_for(reader.read(4096), timeout=30.0)
+                except asyncio.TimeoutError:
+                    continue
+                if not data:
+                    break
+                buf += data
+                _LOGGER.debug("Dynalite TCP received %s bytes, buf len now %s", len(data), len(buf))
+                while len(buf) >= FRAME_LEN:
+                    frame = buf[:FRAME_LEN]
+                    buf = buf[FRAME_LEN:]
+                    parsed = parse_frame(frame, parse_layout)
+                    if parsed:
+                        area, channel, value = parsed
+                        _LOGGER.debug("Dynalite TCP dispatching area=%s channel=%s value=%s", area, channel, value)
+                        hass.async_create_task(
+                            _invoke_callback_async(hass, entry_id, area, channel, value)
+                        )
+        except asyncio.CancelledError:
+            break
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Dynalite TCP read error: %s", err)
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+async def _invoke_callback_async(
+    hass: HomeAssistant, entry_id: str, area: int, channel: int, value: int
+) -> None:
+    """Invoke the registered callback on the event loop."""
+    _LOGGER.debug("Dynalite invoking callback entry_id=%s area=%s channel=%s value=%s", entry_id, area, channel, value)
+    cb = _get_callback(hass, entry_id)
+    if cb:
+        try:
+            if asyncio.iscoroutinefunction(cb):
+                await cb(area, channel, value)
+            else:
+                cb(area, channel, value)
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Dynalite event callback error for area=%s ch=%s", area, channel)
+    else:
+        _LOGGER.debug("Dynalite no callback registered for entry_id=%s", entry_id)
+
+
+def start_dynalite_listener(hass: HomeAssistant, entry: ConfigEntry, config: dict[str, Any]) -> None:
+    """Start the Dynalite TCP event listener."""
+    entry_id = entry.entry_id
+    if not config.get(CONF_DYNALITE_ENABLED):
+        return
+    entry_data = hass.data.setdefault(DOMAIN, {}).setdefault(entry_id, {})
+
+    stop_dynalite_listener(hass, entry_id)
+
+    host = (config.get(CONF_DYNALITE_HOST) or "").strip()
+    port = config.get(CONF_DYNALITE_PORT, DEFAULT_DYNALITE_PORT)
+    if not host:
+        _LOGGER.warning("Dynalite listener enabled but no host configured")
+        return
+    shutdown = asyncio.Event()
+    entry_data["dynalite_shutdown"] = shutdown
+    parse_layout = config.get(
+        CONF_DYNALITE_PARSE_LAYOUT, DEFAULT_DYNALITE_PARSE_LAYOUT
+    )
+    task = asyncio.create_task(
+        _run_tcp_listener(hass, entry_id, host, port, shutdown, parse_layout)
+    )
+    entry_data["dynalite_task"] = task
+    _LOGGER.info(
+        "Dynalite TCP listener started for %s:%s (parse layout=%s)",
+        host,
+        port,
+        parse_layout,
+    )
+
+
+def stop_dynalite_listener(hass: HomeAssistant, entry_id: str) -> None:
+    """Stop the Dynalite TCP listener."""
+    entry_data = (hass.data.get(DOMAIN) or {}).get(entry_id)
+    if not entry_data:
+        return
+    task = entry_data.pop("dynalite_task", None)
+    if task is not None and not task.done():
+        task.cancel()
+    shutdown = entry_data.pop("dynalite_shutdown", None)
+    if shutdown is not None:
+        shutdown.set()
+    _LOGGER.debug("Dynalite listener stopped for entry %s", entry_id)

--- a/custom_components/control4/sensor.py
+++ b/custom_components/control4/sensor.py
@@ -31,6 +31,7 @@ class _SensorMap:
     proxies: set[str] | None = None
 
 SENSORS: list[_SensorMap] = [
+    # Power/energy (proxy in config)
     _SensorMap(
         key="CURRENT_POWER",
         name_suffix="Power",
@@ -55,6 +56,23 @@ SENSORS: list[_SensorMap] = [
         state_class=SensorStateClass.TOTAL,
         proxies={"light_v2"},
     ),
+    # Trigger/level preset (proxy in config)
+    _SensorMap(
+        key="LEVEL",
+        name_suffix="Level",
+        unit=None,
+        device_class=None,
+        state_class=None,
+        proxies={"dynalite_trigger"},
+    ),
+    _SensorMap(
+        key="PRESET",
+        name_suffix="Preset",
+        unit=None,
+        device_class=None,
+        state_class=None,
+        proxies={"dynalite_trigger"},
+    ),
 ]
 
 
@@ -65,6 +83,7 @@ async def async_setup_entry(
 
     director_all_items = entry_data[CONF_DIRECTOR_ALL_ITEMS]
     entities: list[Control4AttrSensor] = []
+    unmatched_vars_sample: list[tuple[int, str, list[str]]] = []  # (id, name, var_names) when no SENSORS match
 
     for item in director_all_items:
         try:
@@ -74,29 +93,31 @@ async def async_setup_entry(
             item_id = item["id"]
             item_area = item["roomName"]
             item_parent_id = item["parentId"]
+            item_proxy = item.get("proxy")
 
             item_manufacturer = None
             item_device_name = None
             item_model = None
 
             for parent_item in director_all_items:
-                if parent_item["id"] == item_parent_id:
-                    item_manufacturer = parent_item["manufacturer"]
-                    item_device_name = parent_item["name"]
-                    item_model = parent_item["model"]
+                if parent_item.get("id") == item_parent_id:
+                    item_manufacturer = parent_item.get("manufacturer")
+                    item_device_name = parent_item.get("name")
+                    item_model = parent_item.get("model")
+                    break
 
-            # Get the item's attrs (not the parent)
-            attrs = await director_get_entry_variables(hass, entry, item_id)
+            # Get the item's attrs (not the parent); normalize keys to uppercase to match WS updates
+            raw_attrs = await director_get_entry_variables(hass, entry, item_id)
+            attrs = {str(k).upper(): v for k, v in raw_attrs.items()}
 
             for sm in SENSORS:
-                # Only match if the key and proxy match
-                if sm.key in attrs and (sm.proxies and item.get("proxy") in sm.proxies):
+                if sm.key in attrs and (sm.proxies and item_proxy in sm.proxies):
                     entities.append(
                         Control4AttrSensor(
                             entry_data=entry_data,
                             entry=entry,
                             name=sm.name_suffix,
-                            idx=item_id,  # Use the item's ID
+                            idx=item_id,
                             device_name=item_device_name,
                             device_manufacturer=item_manufacturer,
                             device_model=item_model,
@@ -107,12 +128,32 @@ async def async_setup_entry(
                         )
                     )
 
+            # Collect variable names when no SENSORS entry matched (for debug)
+            if attrs and len(unmatched_vars_sample) < 3:
+                if not any(
+                    sm.key in attrs and sm.proxies and item_proxy in sm.proxies for sm in SENSORS
+                ):
+                    unmatched_vars_sample.append((item_id, str(item.get("name", "")), list(attrs.keys())))
+
         except Exception:
-            _LOGGER.debug("Skipping invalid light item: %s", item, exc_info=True)
+            _LOGGER.debug("Skipping invalid sensor item: %s", item, exc_info=True)
             continue
 
     if entities:
         async_add_entities(entities, True)
+        _LOGGER.info("Control4 sensor: set up %d entity(ies)", len(entities))
+    else:
+        _LOGGER.info(
+            "Control4 sensor: no entities found (no devices with variables matching SENSORS config: LEVEL, PRESET, CURRENT_POWER, etc.). "
+            "Only binary_sensor (e.g. Dynalite triggers) may appear. Enable debug for 'custom_components.control4.sensor' to see variable names per device."
+        )
+        for item_id, name, var_names in unmatched_vars_sample:
+            _LOGGER.debug(
+                "id=%s name=%s variable keys: %s (add matching keys to SENSORS if needed)",
+                item_id,
+                name,
+                var_names,
+            )
 
 
 class Control4AttrSensor(Control4Entity, SensorEntity):  # type: ignore[misc]
@@ -149,18 +190,15 @@ class Control4AttrSensor(Control4Entity, SensorEntity):  # type: ignore[misc]
         )
 
         self._sm = sensor_map
-        self._attr_unique_id = f"{idx}-{sensor_map.key.lower()}"
+        self._attr_unique_id = f"{idx}-{sensor_map.key.lower().lstrip('_')}"
         self._attr_native_unit_of_measurement = sensor_map.unit
         self._attr_device_class = sensor_map.device_class
         self._attr_state_class = sensor_map.state_class
-        # Hide from entity registry by default
         self._attr_entity_registry_visible_default = False
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to the existing WebSocket."""
         await super().async_added_to_hass()
-        # The WebSocket is already handled by the parent Control4Entity
-        # No further action required
 
     @property
     def available(self) -> bool:  # type: ignore[override]
@@ -172,13 +210,17 @@ class Control4AttrSensor(Control4Entity, SensorEntity):  # type: ignore[misc]
         raw = self.extra_state_attributes.get(self._sm.key)
         if raw is None:
             return None
-        
+
+        if self._sm.unit is not None:
+            try:
+                val = float(raw)
+            except (TypeError, ValueError):
+                return None
+            if self._sm.value_fn:
+                val = self._sm.value_fn(val)
+            return val
+        # No unit: allow string or number (e.g. Preset name or Level 0-100)
         try:
-            val = float(raw)
+            return float(raw)
         except (TypeError, ValueError):
-            return None
-            
-        if self._sm.value_fn:
-            val = self._sm.value_fn(val)
-            
-        return val
+            return str(raw)

--- a/custom_components/control4/strings.json
+++ b/custom_components/control4/strings.json
@@ -1,4 +1,30 @@
 {
+  "config_flow": {
+    "options": {
+      "step": {
+        "configure": {
+          "title": "Control4 options",
+          "description": "Scan interval, alarm modes, and optional Dynalite TCP gateway.",
+          "data": {
+            "scan_interval": "Seconds between updates (media player only)",
+            "alarm_home_mode": "Alarm arm home mode name",
+            "alarm_away_mode": "Alarm arm away mode name",
+            "alarm_night_mode": "Alarm arm night mode name",
+            "alarm_custom_bypass_mode": "Alarm arm custom bypass mode name",
+            "alarm_vacation_mode": "Alarm arm vacation mode name",
+            "dynalite_enabled": "Enable Dynalite gateway listener (TCP)"
+          }
+        },
+        "configure_dynalite_tcp": {
+          "data": {
+            "dynalite_host": "Dynalite gateway IP",
+            "dynalite_port": "Dynalite gateway port",
+            "dynalite_parse_layout": "TCP frame layout"
+          }
+        }
+      }
+    }
+  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
@@ -31,13 +57,31 @@
   "options": {
     "step": {
       "init": {
+        "title": "Control4 settings",
+        "description": "{heading}",
+        "data": {
+          "Settings": "What do you want to do?"
+        }
+      },
+      "configure": {
+        "title": "Configure options",
+        "description": "Scan interval, alarm modes, and optional Dynalite TCP gateway.",
         "data": {
           "scan_interval": "Seconds between updates (media player only)",
           "alarm_home_mode": "Alarm arm home mode name",
           "alarm_away_mode": "Alarm arm away mode name",
           "alarm_night_mode": "Alarm arm night mode name",
           "alarm_custom_bypass_mode": "Alarm arm custom bypass mode name",
-          "alarm_vacation_mode": "Alarm arm vacation mode name"
+          "alarm_vacation_mode": "Alarm arm vacation mode name",
+          "dynalite_enabled": "Enable Dynalite gateway listener (TCP)"
+        }
+      },
+      "configure_dynalite_tcp": {
+        "title": "Dynalite TCP connection",
+        "data": {
+          "dynalite_host": "Dynalite gateway IP",
+          "dynalite_port": "Dynalite gateway port",
+          "dynalite_parse_layout": "TCP frame layout"
         }
       }
     }

--- a/custom_components/control4/translations/en.json
+++ b/custom_components/control4/translations/en.json
@@ -1,36 +1,89 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "host": "IP Address",
-                    "password": "Password",
-                    "username": "Username"
-                },
-                "description": "Please enter your Control4 account details and the IP address of your local controller."
-            }
-        }
-    },
+  "config_flow": {
     "options": {
       "step": {
-        "init": {
+        "configure": {
+          "title": "Control4 options",
+          "description": "Scan interval, alarm modes, and optional Dynalite TCP gateway.",
           "data": {
             "scan_interval": "Seconds between updates (media player only)",
             "alarm_home_mode": "Alarm arm home mode name",
             "alarm_away_mode": "Alarm arm away mode name",
             "alarm_night_mode": "Alarm arm night mode name",
             "alarm_custom_bypass_mode": "Alarm arm custom bypass mode name",
-            "alarm_vacation_mode": "Alarm arm vacation mode name"
+            "alarm_vacation_mode": "Alarm arm vacation mode name",
+            "dynalite_enabled": "Enable Dynalite gateway listener (TCP)"
+          }
+        },
+        "configure_dynalite_tcp": {
+          "data": {
+            "dynalite_host": "Dynalite gateway IP",
+            "dynalite_port": "Dynalite gateway port",
+            "dynalite_parse_layout": "TCP frame layout"
           }
         }
       }
     }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::ip%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "description": "Please enter your Control4 account details and the IP address of your local controller."
+      },
+      "user_reauth": {
+        "data": {
+          "host": "[%key:common::config_flow::data::ip%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "description": "Please reenter your Control4 account details and the IP address of your local controller."
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Control4 settings",
+        "description": "{heading}",
+        "data": {
+          "Settings": "What do you want to do?"
+        }
+      },
+      "configure": {
+        "title": "Configure options",
+        "description": "Scan interval, alarm modes, and optional Dynalite TCP gateway.",
+        "data": {
+          "scan_interval": "Seconds between updates (media player only)",
+          "alarm_home_mode": "Alarm arm home mode name",
+          "alarm_away_mode": "Alarm arm away mode name",
+          "alarm_night_mode": "Alarm arm night mode name",
+          "alarm_custom_bypass_mode": "Alarm arm custom bypass mode name",
+          "alarm_vacation_mode": "Alarm arm vacation mode name",
+          "dynalite_enabled": "Enable Dynalite gateway listener (TCP)"
+        }
+      },
+      "configure_dynalite_tcp": {
+        "title": "Dynalite TCP connection",
+        "data": {
+          "dynalite_host": "Dynalite gateway IP",
+          "dynalite_port": "Dynalite gateway port",
+          "dynalite_parse_layout": "TCP frame layout"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What this does
Some Dynalite-related sensors exist in Control4 as **dynalite_trigger** devices, but **their events are not available to Home Assistant** through the usual Control4/Director path.

This change **reads events directly from the Dynalite gateway over TCP**, parses **DyNet-style frames**, matches **area/channel** to **dynalite_trigger** items from loaded Director data, and **updates the corresponding HA binary_sensor entities**.

## Sensor platform
Variable-backed **sensor** entities are created from a declarative **`SENSORS` / `_SensorMap`** list (Control4 **proxy** + **variable name**). Adding support for more devices or variables is done by extending that list instead of hardcoding separate setup flows per type.

## User-visible behavior
- Optional **Dynalite TCP** settings: enable, gateway host/port, **frame layout** (DyNet vs legacy).
- **Enable** is offered only when the project includes at least one **dynalite_trigger**; the listener starts only in that case.

## Testing
- [x] With `dynalite_trigger` devices and correct gateway host/port, physical triggers pulse HA binary_sensors.
- [x] With no `dynalite_trigger` devices, Dynalite enable is not shown and no listener runs.
