### PR TITLE
Add uibutton garage cover support

### DIFF
--- a/custom_components/control4/cover.py
+++ b/custom_components/control4/cover.py
@@ -1,10 +1,12 @@
-"""Platform for Control4 Covers (blinds/shades)."""
+"""Platform for Control4 Covers (blinds/shades and garage doors)."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
 from homeassistant.components.cover import (
+	CoverDeviceClass,
 	CoverEntity,
 	CoverEntityFeature,
 )
@@ -34,6 +36,12 @@ _COVER_PROXY_SUBSTRINGS = (
 	"drap",
 )
 
+_GARAGE_PARENT_TYPE = 6
+_GARAGE_PROXY = "uibutton"
+_GARAGE_PARENT_NAME = "relay garage door controller"
+_GARAGE_PARENT_MODEL = "1-3 relays"
+_GARAGE_STATE_VARIABLE = "STATE"
+
 
 async def async_setup_entry(
 	hass: HomeAssistant,
@@ -53,6 +61,20 @@ async def async_setup_entry(
 		p = proxy_value.lower()
 		return any(s in p for s in _COVER_PROXY_SUBSTRINGS)
 
+	def _is_garage_parent(item: dict[str, Any]) -> bool:
+		name = str(item.get("name", "")).lower()
+		model = str(item.get("model", "")).lower()
+		return (
+			item.get("type") == _GARAGE_PARENT_TYPE
+			and item.get("proxy") == _GARAGE_PROXY
+			and _GARAGE_PARENT_NAME in name
+			and _GARAGE_PARENT_MODEL in model
+		)
+
+	garage_parent_ids = {
+		item["id"] for item in all_items if item.get("id") and _is_garage_parent(item)
+	}
+
 	# Identify cover entities via proxy type heuristics
 	cover_items: list[dict[str, Any]] = [
 		item
@@ -62,7 +84,16 @@ async def async_setup_entry(
 		and _is_cover_proxy(item.get("proxy"))
 	]
 
-	entity_list: list[Control4Cover] = []
+	garage_items: list[dict[str, Any]] = [
+		item
+		for item in all_items
+		if item.get("type") == CONTROL4_ENTITY_TYPE
+		and item.get("id")
+		and item.get("proxy") == _GARAGE_PROXY
+		and item.get("parentId") in garage_parent_ids
+	]
+
+	entity_list: list[CoverEntity] = []
 
 	for item in cover_items:
 		try:
@@ -91,6 +122,45 @@ async def async_setup_entry(
 
 		entity_list.append(
 			Control4Cover(
+				entry_data,
+				entry,
+				item_name,
+				item_id,
+				item_device_name,
+				item_manufacturer,
+				item_model,
+				item_parent_id,
+				item_area,
+				item_attributes,
+			)
+		)
+
+	for item in garage_items:
+		try:
+			item_name = str(item["name"])
+			item_id = item["id"]
+			item_area = item.get("roomName")
+			item_parent_id = item["parentId"]
+
+			parent = items_by_id.get(item_parent_id, {})
+			item_manufacturer = parent.get("manufacturer")
+			item_device_name = item_name
+			item_model = parent.get("model")
+		except KeyError:
+			_LOGGER.exception(
+				"Unknown garage door properties received from Control4: %s",
+				item,
+			)
+			continue
+
+		item_attributes = await director_get_entry_variables(hass, entry, item_id)
+		if _GARAGE_STATE_VARIABLE not in item_attributes:
+			item_attributes.update(
+				await director_get_entry_variables(hass, entry, item_parent_id)
+			)
+
+		entity_list.append(
+			Control4GarageCover(
 				entry_data,
 				entry,
 				item_name,
@@ -154,4 +224,86 @@ class Control4Cover(Control4Entity, CoverEntity):  # type: ignore[misc]
 		"""Stop the cover."""
 		c4_blind = self.create_api_object()
 		await c4_blind.stop()
+
+
+class Control4GarageCover(Control4Entity, CoverEntity):  # type: ignore[misc]
+	"""Control4 garage door exposed through a uibutton relay driver."""
+	_attr_device_class = CoverDeviceClass.GARAGE
+	_attr_supported_features = (
+		CoverEntityFeature.OPEN
+		| CoverEntityFeature.CLOSE
+		| CoverEntityFeature.STOP
+	)
+
+	@property
+	def _garage_state(self) -> str:
+		value = self._extra_state_attributes.get(_GARAGE_STATE_VARIABLE)
+		if value is None:
+			value = self._extra_state_attributes.get(_GARAGE_STATE_VARIABLE.lower())
+		return str(value or "").strip().lower()
+
+	@property
+	def is_closed(self) -> bool | None:  # type: ignore[override]
+		"""Return whether the garage door is closed."""
+		state = self._garage_state
+		if state in {"closed", "close"}:
+			return True
+		if state in {"open", "opened", "opening", "closing", "stopped", "partial"}:
+			return False
+		return None
+
+	@property
+	def is_opening(self) -> bool:  # type: ignore[override]
+		"""Return whether the garage door is opening."""
+		return self._garage_state == "opening"
+
+	@property
+	def is_closing(self) -> bool:  # type: ignore[override]
+		"""Return whether the garage door is closing."""
+		return self._garage_state == "closing"
+
+	async def _send_garage_command(self, command: str) -> None:
+		director = self.entry_data[CONF_DIRECTOR]
+		await director.send_post_request(
+			f"/api/v1/items/{self._device_id}/commands",
+			command,
+			{},
+		)
+		await asyncio.sleep(1)
+		try:
+			self._extra_state_attributes.update(
+				await director_get_entry_variables(
+					self.hass, self.entry, self._device_id
+				)
+			)
+		except Exception as err:  # noqa: BLE001
+			_LOGGER.debug("Unable to refresh Control4 garage state: %s", err)
+
+	async def _data_to_extra_state_attributes(self, data) -> None:
+		"""Load garage state from websocket update data."""
+		if isinstance(data, dict):
+			for key in (_GARAGE_STATE_VARIABLE, _GARAGE_STATE_VARIABLE.lower()):
+				value = data.get(key)
+				if isinstance(value, dict):
+					for state_key in ("current_state", "value", "STATE", "state"):
+						if state_key in value:
+							self._extra_state_attributes[_GARAGE_STATE_VARIABLE] = value[
+								state_key
+							]
+							break
+				elif value is not None:
+					self._extra_state_attributes[_GARAGE_STATE_VARIABLE] = value
+		await super()._data_to_extra_state_attributes(data)
+
+	async def async_open_cover(self, **kwargs: Any) -> None:
+		"""Open the garage door."""
+		await self._send_garage_command("OPEN")
+
+	async def async_close_cover(self, **kwargs: Any) -> None:
+		"""Close the garage door."""
+		await self._send_garage_command("CLOSE")
+
+	async def async_stop_cover(self, **kwargs: Any) -> None:
+		"""Stop the garage door."""
+		await self._send_garage_command("STOP")
 

--- a/custom_components/control4/cover.py
+++ b/custom_components/control4/cover.py
@@ -41,6 +41,9 @@ _GARAGE_PROXY = "uibutton"
 _GARAGE_PARENT_NAME = "relay garage door controller"
 _GARAGE_PARENT_MODEL = "1-3 relays"
 _GARAGE_STATE_VARIABLE = "STATE"
+_GARAGE_ICON_VARIABLE = "ICON"
+_GARAGE_ICON_DESCRIPTION_VARIABLE = "ICON_DESCRIPTION"
+_GARAGE_REFRESH_DELAYS = (1, 5, 15, 30, 60)
 
 
 async def async_setup_entry(
@@ -229,6 +232,7 @@ class Control4Cover(Control4Entity, CoverEntity):  # type: ignore[misc]
 class Control4GarageCover(Control4Entity, CoverEntity):  # type: ignore[misc]
 	"""Control4 garage door exposed through a uibutton relay driver."""
 	_attr_device_class = CoverDeviceClass.GARAGE
+	_attr_should_poll = True
 	_attr_supported_features = (
 		CoverEntityFeature.OPEN
 		| CoverEntityFeature.CLOSE
@@ -237,10 +241,33 @@ class Control4GarageCover(Control4Entity, CoverEntity):  # type: ignore[misc]
 
 	@property
 	def _garage_state(self) -> str:
-		value = self._extra_state_attributes.get(_GARAGE_STATE_VARIABLE)
-		if value is None:
-			value = self._extra_state_attributes.get(_GARAGE_STATE_VARIABLE.lower())
-		return str(value or "").strip().lower()
+		state = self._normalized_attribute(
+			_GARAGE_STATE_VARIABLE,
+			_GARAGE_STATE_VARIABLE.lower(),
+		)
+		if state in {"opening", "closing"}:
+			return state
+
+		icon_state = self._normalized_attribute(
+			_GARAGE_ICON_DESCRIPTION_VARIABLE,
+			_GARAGE_ICON_DESCRIPTION_VARIABLE.lower(),
+			"icon_description",
+			_GARAGE_ICON_VARIABLE,
+			_GARAGE_ICON_VARIABLE.lower(),
+		)
+		if "closed" in icon_state:
+			return "closed"
+		if "open" in icon_state:
+			return "open"
+
+		return state
+
+	def _normalized_attribute(self, *keys: str) -> str:
+		for key in keys:
+			value = self._extra_state_attributes.get(key)
+			if value is not None:
+				return str(value).strip().lower().replace("_", " ")
+		return ""
 
 	@property
 	def is_closed(self) -> bool | None:  # type: ignore[override]
@@ -262,6 +289,28 @@ class Control4GarageCover(Control4Entity, CoverEntity):  # type: ignore[misc]
 		"""Return whether the garage door is closing."""
 		return self._garage_state == "closing"
 
+	async def async_update(self) -> None:
+		"""Poll the parent relay driver for the latest garage state."""
+		await self._refresh_garage_state(write_state=False)
+
+	async def _refresh_garage_state(self, *, write_state: bool = True) -> None:
+		attrs = await director_get_entry_variables(self.hass, self.entry, self._device_id)
+		if _GARAGE_STATE_VARIABLE not in attrs:
+			attrs.update(
+				await director_get_entry_variables(self.hass, self.entry, self._idx)
+			)
+		self._attr_available = True
+		self._extra_state_attributes.update(attrs)
+		if write_state:
+			self.async_write_ha_state()
+
+	async def _refresh_garage_state_after_delay(self, delay: int) -> None:
+		await asyncio.sleep(delay)
+		try:
+			await self._refresh_garage_state()
+		except Exception as err:  # noqa: BLE001
+			_LOGGER.debug("Unable to refresh Control4 garage state: %s", err)
+
 	async def _send_garage_command(self, command: str) -> None:
 		director = self.entry_data[CONF_DIRECTOR]
 		await director.send_post_request(
@@ -269,15 +318,16 @@ class Control4GarageCover(Control4Entity, CoverEntity):  # type: ignore[misc]
 			command,
 			{},
 		)
-		await asyncio.sleep(1)
-		try:
-			self._extra_state_attributes.update(
-				await director_get_entry_variables(
-					self.hass, self.entry, self._device_id
-				)
-			)
-		except Exception as err:  # noqa: BLE001
-			_LOGGER.debug("Unable to refresh Control4 garage state: %s", err)
+		optimistic_state = {
+			"OPEN": "opening",
+			"CLOSE": "closing",
+			"STOP": "stopped",
+		}.get(command)
+		if optimistic_state:
+			self._extra_state_attributes[_GARAGE_STATE_VARIABLE] = optimistic_state
+			self.async_write_ha_state()
+		for delay in _GARAGE_REFRESH_DELAYS:
+			self.hass.async_create_task(self._refresh_garage_state_after_delay(delay))
 
 	async def _data_to_extra_state_attributes(self, data) -> None:
 		"""Load garage state from websocket update data."""

--- a/custom_components/control4/cover.py
+++ b/custom_components/control4/cover.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Any
 
 from homeassistant.components.cover import (
@@ -43,7 +44,8 @@ _GARAGE_PARENT_MODEL = "1-3 relays"
 _GARAGE_STATE_VARIABLE = "STATE"
 _GARAGE_ICON_VARIABLE = "ICON"
 _GARAGE_ICON_DESCRIPTION_VARIABLE = "ICON_DESCRIPTION"
-_GARAGE_REFRESH_DELAYS = (1, 5, 15, 30, 60)
+_GARAGE_REFRESH_DELAYS = (5, 10, 20, 35, 60)
+_GARAGE_TRANSITION_TIMEOUT = 45
 
 
 async def async_setup_entry(
@@ -239,8 +241,25 @@ class Control4GarageCover(Control4Entity, CoverEntity):  # type: ignore[misc]
 		| CoverEntityFeature.STOP
 	)
 
+	def __init__(self, *args: Any, **kwargs: Any) -> None:
+		super().__init__(*args, **kwargs)
+		self._transition_state: str | None = None
+		self._transition_target_state: str | None = None
+		self._transition_deadline = 0.0
+
 	@property
 	def _garage_state(self) -> str:
+		state = self._resolved_garage_state()
+		if self._transition_state and self._transition_target_state:
+			if state == self._transition_target_state:
+				self._clear_transition()
+				return state
+			if time.monotonic() < self._transition_deadline:
+				return self._transition_state
+			self._clear_transition()
+		return state
+
+	def _resolved_garage_state(self) -> str:
 		state = self._normalized_attribute(
 			_GARAGE_STATE_VARIABLE,
 			_GARAGE_STATE_VARIABLE.lower(),
@@ -268,6 +287,11 @@ class Control4GarageCover(Control4Entity, CoverEntity):  # type: ignore[misc]
 			if value is not None:
 				return str(value).strip().lower().replace("_", " ")
 		return ""
+
+	def _clear_transition(self) -> None:
+		self._transition_state = None
+		self._transition_target_state = None
+		self._transition_deadline = 0.0
 
 	@property
 	def is_closed(self) -> bool | None:  # type: ignore[override]
@@ -324,6 +348,15 @@ class Control4GarageCover(Control4Entity, CoverEntity):  # type: ignore[misc]
 			"STOP": "stopped",
 		}.get(command)
 		if optimistic_state:
+			if command == "OPEN":
+				self._transition_target_state = "open"
+				self._transition_deadline = time.monotonic() + _GARAGE_TRANSITION_TIMEOUT
+			elif command == "CLOSE":
+				self._transition_target_state = "closed"
+				self._transition_deadline = time.monotonic() + _GARAGE_TRANSITION_TIMEOUT
+			else:
+				self._clear_transition()
+			self._transition_state = optimistic_state
 			self._extra_state_attributes[_GARAGE_STATE_VARIABLE] = optimistic_state
 			self.async_write_ha_state()
 		for delay in _GARAGE_REFRESH_DELAYS:


### PR DESCRIPTION
﻿## Summary

Add garage-door cover support for Control4 projects where garage doors are exposed as `uibutton` child items under `Relay Garage Door Controller (OS2.9+)` parent devices.

The existing cover platform only discovers blind/shade-like proxies. Some garage-door Control4 drivers, including Intrinsic/myQ-backed setups, expose a user-facing `uibutton` child while the parent relay controller owns the `OPEN`, `CLOSE`, and `STOP` commands plus a `STATE` variable.

## Implementation

- Keeps the existing blind/shade discovery unchanged.
- Adds a narrow garage discovery path for:
  - parent type `6`
  - parent proxy `uibutton`
  - parent name containing `relay garage door controller`
  - parent model containing `1-3 relays`
  - child type `7` / `CONTROL4_ENTITY_TYPE`
  - child proxy `uibutton`
- Exposes matching children as `CoverDeviceClass.GARAGE` entities.
- Sends `OPEN`, `CLOSE`, and `STOP` to the parent controller item.
- Reads the parent `STATE` variable to report closed/opening/closing/open-ish state.

## Validation

- Syntax checked with Python `compile()`.
- Tested on a live Home Assistant custom component install using five Intrinsic/myQ-backed Control4 garage doors.
- Home Assistant created five garage `cover` entities, all reporting `closed` from the parent `STATE` variable with open/close/stop support.

I did not include any Home Assistant config, credentials, or site-specific entity IDs in this PR.
