### PR TITLE
Expose Control4 schedule presets and Hold as climate preset_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hass-control4
 
-This custom integration for Home Assistant allows control of Control4 lights, locks (only locks that are relay-based in Control4), alarm control panels, door/window/motion sensors (as binary sensors), thermostats, fans, relay devices (as switches), and blinds/shades (as covers, stateless open/close/stop).
+This custom integration for Home Assistant allows control of Control4 lights, locks (only locks that are relay-based in Control4), alarm control panels, door/window/motion sensors (as binary sensors), thermostats (including schedule presets and hold), fans, relay devices (as switches), and blinds/shades (as covers, stateless open/close/stop).
 
 ## Installation
 
@@ -11,6 +11,16 @@ Then, you can use the link below to install the integration through HACS:
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=lawtancool&repository=hass-control4)
 
 Once installed, follow the same setup instructions as the default integration: https://www.home-assistant.io/integrations/control4
+
+### Climate presets (thermostats)
+
+Control4 schedule activities (`SET_PRESET`, e.g. Home / Away / Night) and permanent hold are exposed together as Home Assistant `climate` preset modes:
+
+- Configure the available schedule names under **Settings → Devices & services → Control4 → Configure** (`Climate schedule presets`, comma-separated). Default: `Night, Evening, Day, Home, Away, Off`
+- Names must match Control4 exactly (spelling and casing)
+- Choosing a schedule preset clears hold, then applies that activity
+- Choosing `Hold` enables permanent hold on the current setpoints
+- Legacy hold values `Permanent` / `Off` still work (`Permanent` → Hold, `Off` → clear hold only)
 
 ### Additional configuration required for alarm control panel
 

--- a/custom_components/control4/climate.py
+++ b/custom_components/control4/climate.py
@@ -29,7 +29,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyControl4.climate import C4Climate
 
 from . import Control4Entity, get_items_of_category
-from .const import CONF_DIRECTOR, CONTROL4_ENTITY_TYPE, DOMAIN
+from .const import (
+    CONF_CLIMATE_SCHEDULE_PRESETS,
+    CONF_DIRECTOR,
+    CONTROL4_ENTITY_TYPE,
+    DOMAIN,
+    parse_climate_schedule_presets,
+)
 from .director_utils import director_get_entry_variables
 
 _LOGGER = logging.getLogger(__name__)
@@ -75,6 +81,13 @@ FAN_MODES = {
     CONTROL4_FAN_MODE_DIFFUSE: FAN_DIFFUSE,
 }
 
+# Combined HA climate.preset_mode values.
+# Control4 has orthogonal schedule presets (SET_PRESET) and hold (SET_MODE_HOLD);
+# HA only exposes one preset_mode, so they are merged here.
+PRESET_HOLD = "Hold"
+CONTROL4_HOLD_OFF = "Off"
+CONTROL4_HOLD_PERMANENT = "Permanent"
+
 # Attribute name constants
 ATTR_HUMIDITY = "HUMIDITY"
 ATTR_TEMPERATURE_F = "TEMPERATURE_F"
@@ -87,6 +100,8 @@ ATTR_HVAC_MODE = "HVAC_MODE"
 ATTR_HVAC_MODES_LIST = "HVAC_MODES_LIST"
 ATTR_HOLD_MODE = "HOLD_MODE"
 ATTR_HOLD_MODES_LIST = "HOLD_MODES_LIST"
+ATTR_PRESET = "PRESET"
+ATTR_PRESETS_LIST = "PRESETS_LIST"
 ATTR_SETPOINT_HEAT_F = "SETPOINT_HEAT_F"
 ATTR_HEAT_SETPOINT_F = "HEAT_SETPOINT_F"
 ATTR_SETPOINT_HEAT_C = "SETPOINT_HEAT_C"
@@ -204,6 +219,7 @@ class Control4Climate(Control4Entity, ClimateEntity):  # type: ignore[misc]
         else:
             self._thermostat_setup = {}
         self._aux_heat_active = False
+        self._discovered_schedule_presets: set[str] = set()
 
     def create_api_object(self):
         """Create a pyControl4 device object.
@@ -244,18 +260,110 @@ class Control4Climate(Control4Entity, ClimateEntity):  # type: ignore[misc]
             return [FAN_MODES[x] for x in control4_fan_modes if x in FAN_MODES]
         return list(FAN_MODES.values())
 
+    @staticmethod
+    def _split_csv(value: str | list[str] | None) -> list[str]:
+        """Split a Control4 CSV list attribute into stripped items."""
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        return [item.strip() for item in str(value).split(",") if item.strip()]
+
+    def _control4_hold_mode(self) -> str | None:
+        """Return raw Control4 HOLD_MODE."""
+        hold = self._extra_state_attributes.get(ATTR_HOLD_MODE)
+        if hold is None:
+            return None
+        hold_str = str(hold).strip()
+        return hold_str or None
+
+    def _hold_is_active(self) -> bool:
+        """True when Control4 hold is anything other than Off."""
+        hold = self._control4_hold_mode()
+        if hold is None:
+            return False
+        return hold.casefold() != CONTROL4_HOLD_OFF.casefold()
+
+    def _schedule_preset(self) -> str | None:
+        """Return the Control4 schedule preset name (PRESET), if any."""
+        preset = self._extra_state_attributes.get(ATTR_PRESET)
+        if preset is None:
+            return None
+        preset_str = str(preset).strip()
+        if not preset_str or preset_str.casefold() == "undefined":
+            return None
+        self._discovered_schedule_presets.add(preset_str)
+        return preset_str
+
+    def _supports_permanent_hold(self) -> bool:
+        """True if this thermostat advertises Permanent hold."""
+        hold_modes = self._split_csv(
+            self._extra_state_attributes.get(ATTR_HOLD_MODES_LIST)
+        )
+        if not hold_modes:
+            # Domosapiens / Aprilaire drivers commonly support Permanent hold
+            # even when the list attribute is missing.
+            return True
+        return any(
+            mode.casefold() == CONTROL4_HOLD_PERMANENT.casefold()
+            for mode in hold_modes
+        )
+
+    def _configured_schedule_presets(self) -> list[str]:
+        """Schedule presets from integration options (or built-in defaults)."""
+        return parse_climate_schedule_presets(
+            self.entry.options.get(CONF_CLIMATE_SCHEDULE_PRESETS)
+        )
+
     @property
     def preset_modes(self) -> list[str] | None:  # type: ignore[override]
-        """Return the list of available preset modes."""
-        preset_modes = self._extra_state_attributes.get(ATTR_HOLD_MODES_LIST)
-        if preset_modes:
-            return preset_modes.split(",")
-        return None
+        """Return combined schedule presets plus hold.
+
+        Schedule presets come from the Configure option (comma-delimited),
+        falling back to built-in defaults, plus any PRESETS_LIST / live PRESET
+        values. Permanent hold is exposed as a single synthetic preset ``Hold``.
+        """
+        modes: list[str] = []
+        seen: set[str] = set()
+        hold_labels = {
+            CONTROL4_HOLD_PERMANENT.casefold(),
+            PRESET_HOLD.casefold(),
+        }
+
+        def _add(name: str) -> None:
+            key = name.casefold()
+            if key in seen or key in hold_labels:
+                return
+            seen.add(key)
+            modes.append(name)
+
+        for name in self._configured_schedule_presets():
+            _add(name)
+
+        for name in self._split_csv(
+            self._extra_state_attributes.get(ATTR_PRESETS_LIST)
+        ):
+            _add(name)
+
+        current = self._schedule_preset()
+        if current:
+            _add(current)
+
+        for name in sorted(self._discovered_schedule_presets, key=str.casefold):
+            _add(name)
+
+        if self._supports_permanent_hold() and PRESET_HOLD.casefold() not in seen:
+            seen.add(PRESET_HOLD.casefold())
+            modes.append(PRESET_HOLD)
+
+        return modes or None
 
     @property
     def preset_mode(self) -> str | None:  # type: ignore[override]
-        """Return the current preset mode."""
-        return self._extra_state_attributes.get(ATTR_HOLD_MODE)
+        """Return hold when active, otherwise the schedule preset."""
+        if self._hold_is_active():
+            return PRESET_HOLD
+        return self._schedule_preset()
 
     @property
     def hvac_action(self) -> HVACAction | None:  # type: ignore[override]
@@ -429,10 +537,29 @@ class Control4Climate(Control4Entity, ClimateEntity):  # type: ignore[misc]
             )
 
     async def async_set_preset_mode(self, preset_mode) -> None:
-        """Set new target preset mode."""
-        c4_climate = self.create_api_object()
-        await c4_climate.set_hold_mode(preset_mode)
+        """Set schedule preset or permanent hold.
 
+        Selecting a schedule preset clears hold (``Off``) then applies
+        ``SET_PRESET``. Selecting ``Hold`` (or legacy ``Permanent``) enables
+        permanent hold on the current setpoints. Legacy ``Off`` only clears
+        hold so the thermostat follows its schedule again.
+        """
+        c4_climate = self.create_api_object()
+        requested = str(preset_mode).strip()
+        requested_key = requested.casefold()
+
+        if requested_key in {PRESET_HOLD.casefold(), CONTROL4_HOLD_PERMANENT.casefold()}:
+            await c4_climate.set_hold_mode(CONTROL4_HOLD_PERMANENT)
+            return
+
+        if requested_key == CONTROL4_HOLD_OFF.casefold():
+            await c4_climate.set_hold_mode(CONTROL4_HOLD_OFF)
+            return
+
+        # Schedule preset: release hold first so the new activity is active.
+        await c4_climate.set_hold_mode(CONTROL4_HOLD_OFF)
+        await c4_climate.set_preset(requested)
+        self._discovered_schedule_presets.add(requested)
 
     async def _set_cool_setpoint(self, temp) -> None:
         c4_climate = self.create_api_object()

--- a/custom_components/control4/config_flow.py
+++ b/custom_components/control4/config_flow.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_ALARM_HOME_MODE,
     CONF_ALARM_NIGHT_MODE,
     CONF_ALARM_VACATION_MODE,
+    CONF_CLIMATE_SCHEDULE_PRESETS,
     CONF_CONTROLLER_UNIQUE_ID,
     DEFAULT_ALARM_AWAY_MODE,
     DEFAULT_ALARM_CUSTOM_BYPASS_MODE,
@@ -35,6 +36,8 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     MIN_SCAN_INTERVAL,
+    default_climate_schedule_presets_csv,
+    parse_climate_schedule_presets,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -204,7 +207,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Handle options flow."""
         if user_input is not None:
             _LOGGER.debug(user_input)
-            return self.async_create_entry(title="", data=user_input)
+            cleaned = dict(user_input)
+            raw_presets = cleaned.get(CONF_CLIMATE_SCHEDULE_PRESETS)
+            cleaned[CONF_CLIMATE_SCHEDULE_PRESETS] = ", ".join(
+                parse_climate_schedule_presets(
+                    raw_presets if isinstance(raw_presets, str) else None
+                )
+            )
+            return self.async_create_entry(title="", data=cleaned)
 
         # TODO: figure out how to accept empty strings to disable modes
         # TODO: figure out how to only show alarm options if a alarm_control_panel entity exists
@@ -219,6 +229,15 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         has_security = any(
             x.strip() and x.strip() != DEFAULT_ALARM_AWAY_MODE for x in arm_state_choices
         )
+
+        climate_presets_default = self._config_entry.options.get(
+            CONF_CLIMATE_SCHEDULE_PRESETS, default_climate_schedule_presets_csv()
+        )
+        if (
+            not isinstance(climate_presets_default, str)
+            or not climate_presets_default.strip()
+        ):
+            climate_presets_default = default_climate_schedule_presets_csv()
 
         # Always include scan interval; include alarm options only if we have a panel
         if has_security:
@@ -260,6 +279,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_ALARM_VACATION_MODE, DEFAULT_ALARM_VACATION_MODE
                         ),
                     ): vol.In(sorted(arm_state_choices)),
+                    vol.Optional(
+                        CONF_CLIMATE_SCHEDULE_PRESETS,
+                        default=climate_presets_default,
+                    ): str,
                 },
                 required=False,
             )
@@ -272,6 +295,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                         ),
                     ): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL)),
+                    vol.Optional(
+                        CONF_CLIMATE_SCHEDULE_PRESETS,
+                        default=climate_presets_default,
+                    ): str,
                 },
                 required=False,
             )

--- a/custom_components/control4/const.py
+++ b/custom_components/control4/const.py
@@ -27,6 +27,31 @@ CONF_UI_CONFIGURATION = "ui_configuration"
 DEFAULT_SCAN_INTERVAL = 5
 MIN_SCAN_INTERVAL = 1
 
+# Comma-delimited Control4 schedule activity names shown as climate preset_modes.
+# Director often does not expose PRESETS_LIST; users can override under Configure.
+CONF_CLIMATE_SCHEDULE_PRESETS = "climate_schedule_presets"
+DEFAULT_CLIMATE_SCHEDULE_PRESETS = (
+    "Night",
+    "Evening",
+    "Day",
+    "Home",
+    "Away",
+    "Off",
+)
+
+
+def default_climate_schedule_presets_csv() -> str:
+    """Default schedule presets as a comma-delimited string for the options UI."""
+    return ", ".join(DEFAULT_CLIMATE_SCHEDULE_PRESETS)
+
+
+def parse_climate_schedule_presets(value: str | None) -> list[str]:
+    """Parse a comma-delimited presets option; blank falls back to defaults."""
+    if value is None or not str(value).strip():
+        return list(DEFAULT_CLIMATE_SCHEDULE_PRESETS)
+    return [part.strip() for part in str(value).split(",") if part.strip()]
+
+
 CONF_CONFIG_LISTENER = "config_listener"
 
 CONTROL4_ENTITY_TYPE = 7

--- a/custom_components/control4/manifest.json
+++ b/custom_components/control4/manifest.json
@@ -9,10 +9,10 @@
       "st": "c4:director"
     }
   ],
-  "codeowners": ["@lawtancool"],
+  "codeowners": ["@lawtancool", "@armedad"],
   "integration_type": "hub",
   "iot_class": "local_push",
-  "version": "1.7.0",
+  "version": "1.7.2",
   "issue_tracker": "https://github.com/lawtancool/hass-control4/issues",
   "dependencies": []
 }

--- a/custom_components/control4/strings.json
+++ b/custom_components/control4/strings.json
@@ -31,13 +31,15 @@
   "options": {
     "step": {
       "init": {
+        "description": "Climate schedule presets are a comma-separated list of Control4 activity names (exact spelling/casing).",
         "data": {
           "scan_interval": "Seconds between updates (media player only)",
           "alarm_home_mode": "Alarm arm home mode name",
           "alarm_away_mode": "Alarm arm away mode name",
           "alarm_night_mode": "Alarm arm night mode name",
           "alarm_custom_bypass_mode": "Alarm arm custom bypass mode name",
-          "alarm_vacation_mode": "Alarm arm vacation mode name"
+          "alarm_vacation_mode": "Alarm arm vacation mode name",
+          "climate_schedule_presets": "Climate schedule presets (comma-separated)"
         }
       }
     }

--- a/custom_components/control4/translations/en.json
+++ b/custom_components/control4/translations/en.json
@@ -22,13 +22,15 @@
     "options": {
       "step": {
         "init": {
+          "description": "Climate schedule presets are a comma-separated list of Control4 activity names (exact spelling/casing).",
           "data": {
             "scan_interval": "Seconds between updates (media player only)",
             "alarm_home_mode": "Alarm arm home mode name",
             "alarm_away_mode": "Alarm arm away mode name",
             "alarm_night_mode": "Alarm arm night mode name",
             "alarm_custom_bypass_mode": "Alarm arm custom bypass mode name",
-            "alarm_vacation_mode": "Alarm arm vacation mode name"
+            "alarm_vacation_mode": "Alarm arm vacation mode name",
+            "climate_schedule_presets": "Climate schedule presets (comma-separated)"
           }
         }
       }


### PR DESCRIPTION
## Summary

- Expose Control4 schedule activities (\SET_PRESET\) and permanent hold together as Home Assistant \climate.preset_mode\.
- Control4 treats schedule and hold as separate controls; HA only has one \preset_mode\, so they are merged: schedule names plus a synthetic \Hold\ preset.
- Configurable comma-separated preset list under **Configure** (default: \Night, Evening, Day, Home, Away, Off\). Names must match Control4 exactly.
- Selecting a schedule preset clears hold then applies the activity; selecting \Hold\ enables permanent hold. Legacy \Permanent\ / \Off\ hold values still work.

Made with [Cursor](https://cursor.com)