### PR TITLE
Add full-featured alarm control panel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@ Then, you can use the link below to install the integration through HACS:
 
 Once installed, follow the same setup instructions as the default integration: https://www.home-assistant.io/integrations/control4
 
-### Additional configuration required for alarm control panel
+### Alarm control panel
 
-If you are using an alarm control panel, you must go to Home Assistant -> Configuration -> Devices and Services -> Integrations and click "Configure" on the Control4 entry.
+Arm types are discovered from Control4 (`arm_types` / `arm_states` capabilities and `C4SecurityPanel.get_arm_types()`). On first load, Stay/Away (and other common modes) are auto-mapped to Home Assistant arm home/away when options are still `(not set)`.
 
-In the dialog that appears, choose the Control4 alarm arming modes that you want to correspond to each Home Assistant arming mode. For example, a DSC alarm system uses "Stay" as the "Alarm arm home mode name", and "Away" as the "Alarm arm away mode name". If your alarm system does not use one of the mode names, select `(not set)`. Once you click submit on the dialog, Home Assistant will be able to arm your alarm control panel and detect its state.
+Use **Security System** (the partition with `PARTITION_STATE`) as the primary entity. The companion **Security Panel** UI item is disabled by default when it is not a usable partition.
+
+Entity services:
+
+- `control4.send_alarm_keystrokes` — virtual keypad keystrokes
+- `control4.trigger_emergency` — Fire, Medical, Panic, or Police (when supported)
+
+You can still adjust mode mapping under **Configure** on the Control4 integration entry.
 
 ## Disclaimer
 

--- a/custom_components/control4/__init__.py
+++ b/custom_components/control4/__init__.py
@@ -62,6 +62,7 @@ from .const import (
     SCHEDULE_REFRESH_ADVANCE_SEC,
 )
 from .director_utils import director_get_entry_variables
+from .alarm_utils import apply_auto_mapped_modes, async_discover_alarm_arm_types
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -155,6 +156,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DEFAULT_ALARM_CUSTOM_BYPASS_MODE,
         DEFAULT_ALARM_VACATION_MODE,
     }
+
+    discovered_arm_types = await async_discover_alarm_arm_types(hass, entry, entry_data)
+    new_alarm_options = apply_auto_mapped_modes(
+        entry.options, entry_data, discovered_arm_types
+    )
+    if new_alarm_options is not None:
+        hass.config_entries.async_update_entry(entry, options=new_alarm_options)
+        _LOGGER.info(
+            "Auto-mapped Control4 alarm arm modes: away=%s home=%s",
+            entry_data.get(CONF_ALARM_AWAY_MODE),
+            entry_data.get(CONF_ALARM_HOME_MODE),
+        )
 
     entry_data[CONF_CONFIG_LISTENER] = entry.add_update_listener(update_listener)
 

--- a/custom_components/control4/alarm_control_panel.py
+++ b/custom_components/control4/alarm_control_panel.py
@@ -21,6 +21,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 
 from . import Control4Entity, get_items_of_category
+from .alarm_utils import (
+    CONTROL4_PARTITION_STATE_VAR,
+    is_usable_partition,
+    merge_arm_types_into_cache,
+    parse_arm_types_from_capabilities,
+)
 from .const import (
     CONF_ALARM_ARM_STATES,
     CONF_ALARM_AWAY_MODE,
@@ -49,7 +55,6 @@ CONTROL4_DISARMED_VAR = "DISARMED_STATE"
 CONTROL4_ALARM_STATE_VAR = "ALARM_STATE"
 CONTROL4_DISPLAY_TEXT_VAR = "DISPLAY_TEXT"
 CONTROL4_TROUBLE_TEXT_VAR = "TROUBLE_TEXT"
-CONTROL4_PARTITION_STATE_VAR = "PARTITION_STATE"
 CONTROL4_DELAY_TIME_REMAINING_VAR = "DELAY_TIME_REMAINING"
 CONTROL4_OPEN_ZONE_COUNT_VAR = "OPEN_ZONE_COUNT"
 CONTROL4_ALARM_TYPE_VAR = "ALARM_TYPE"
@@ -60,11 +65,13 @@ CONTROL4_LAST_ARM_FAILURE_VAR = "LAST_ARM_FAILED"
 CONTROL4_EXIT_DELAY_STATE = "EXIT_DELAY"
 CONTROL4_ENTRY_DELAY_STATE = "ENTRY_DELAY"
 CONTROL4_ARMED_STATE = "ARMED"
+CONTROL4_ARMED_HOME_STATE = "ARMED_HOME"
+CONTROL4_ARMED_AWAY_STATE = "ARMED_AWAY"
 CONTROL4_DISARMED_NOT_READY_STATE = "DISARMED_NOT_READY"
 CONTROL4_DISARMED_READY_STATE = "DISARMED_READY"
 
 CONTROL4_PARTITION_STATE_DATA_MAPPING = {
-    "state": "PARTITION_STATE",
+    "state": CONTROL4_PARTITION_STATE_VAR,
     "trouble": "TROUBLE_TEXT",
     "text": "DISPLAY_TEXT",
 }
@@ -74,7 +81,6 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
     """Set up Control4 alarm control panel from a config entry."""
-    # Register alarm_control_panel specific service
     platform = entity_platform.current_platform.get()
     if platform is not None:
         platform.async_register_entity_service(
@@ -82,48 +88,49 @@ async def async_setup_entry(
             {voluptuous.Required("keystrokes"): cv.string},
             "send_alarm_keystrokes",
         )
+        platform.async_register_entity_service(
+            "trigger_emergency",
+            {voluptuous.Required("emergency_type"): cv.string},
+            "async_trigger_emergency",
+        )
 
     entry_data = hass.data[DOMAIN][entry.entry_id]
-
     items_of_category = await get_items_of_category(hass, entry, CONTROL4_CATEGORY)
-
     entity_list = []
-
     director = entry_data[CONF_DIRECTOR]
 
     for item in items_of_category:
         try:
-            if item["type"] == CONTROL4_ENTITY_TYPE and item["id"]:
-                if "capabilities" in item and "arm_states" in item["capabilities"]:
-                    entry_data[CONF_ALARM_ARM_STATES].update(
-                        item["capabilities"]["arm_states"].split(",")
-                    )
-                item_name = str(item["name"])
-                item_id = item["id"]
-                item_area = item["roomName"]
-                item_parent_id = item["parentId"]
-
-                item_manufacturer = None
-                item_device_name = None
-                item_model = None
-
-                try:
-                    item_setup_info = await director.get_item_setup(item_id)
-                    item_enabled = item_setup_info.get("setup", {}).get("enabled", True)
-                except (KeyError, TypeError):
-                    _LOGGER.debug(
-                        "No setup info available for device %s, defaulting to enabled",
-                        item_name,
-                    )
-                    item_enabled = True
-
-                for parent_item in items_of_category:
-                    if parent_item["id"] == item_parent_id:
-                        item_manufacturer = parent_item.get("manufacturer")
-                        item_device_name = parent_item.get("name")
-                        item_model = parent_item.get("model")
-            else:
+            if item["type"] != CONTROL4_ENTITY_TYPE or not item["id"]:
                 continue
+
+            item_name = str(item["name"])
+            item_id = item["id"]
+            item_area = item["roomName"]
+            item_parent_id = item["parentId"]
+            item_manufacturer = None
+            item_device_name = None
+            item_model = None
+
+            capabilities = item.get("capabilities", {})
+            cap_arm_types = parse_arm_types_from_capabilities(capabilities)
+            merge_arm_types_into_cache(entry_data[CONF_ALARM_ARM_STATES], cap_arm_types)
+
+            try:
+                item_setup_info = await director.get_item_setup(item_id)
+                item_enabled = item_setup_info.get("setup", {}).get("enabled", True)
+            except (KeyError, TypeError):
+                _LOGGER.debug(
+                    "No setup info available for device %s, defaulting to enabled",
+                    item_name,
+                )
+                item_enabled = True
+
+            for parent_item in items_of_category:
+                if parent_item["id"] == item_parent_id:
+                    item_manufacturer = parent_item.get("manufacturer")
+                    item_device_name = parent_item.get("name")
+                    item_model = parent_item.get("model")
         except KeyError as exception:
             _LOGGER.debug(
                 "Unknown device properties received from Control4: %s %s",
@@ -133,9 +140,14 @@ async def async_setup_entry(
             continue
 
         item_attributes = await director_get_entry_variables(hass, entry, item_id)
-
         c4_alarm = C4SecurityPanel(director, item_id)
+        item_arm_types = await c4_alarm.get_arm_types()
+        if not item_arm_types:
+            item_arm_types = cap_arm_types
+        merge_arm_types_into_cache(entry_data[CONF_ALARM_ARM_STATES], item_arm_types)
+
         item_emergency_types = await c4_alarm.get_emergency_types()
+        usable = is_usable_partition(item_attributes, item_arm_types)
 
         entity_list.append(
             Control4AlarmControlPanel(
@@ -149,8 +161,10 @@ async def async_setup_entry(
                 item_parent_id,
                 item_area,
                 item_attributes,
-                item_enabled,
+                item_enabled and usable,
                 item_emergency_types,
+                item_arm_types,
+                usable,
             )
         )
 
@@ -174,6 +188,8 @@ class Control4AlarmControlPanel(Control4Entity, AlarmControlPanelEntity):  # typ
         device_attributes: dict,
         is_enabled: bool,
         emergency_types: list[str],
+        arm_types: list[str],
+        is_usable: bool,
     ) -> None:
         """Initialize Control4 alarm control panel entity."""
         super().__init__(
@@ -189,20 +205,24 @@ class Control4AlarmControlPanel(Control4Entity, AlarmControlPanelEntity):  # typ
             device_attributes,
         )
         self._is_enabled = is_enabled
+        self._is_usable = is_usable
         self._emergency_types = emergency_types
+        self._arm_types = arm_types
         self._extra_state_attributes["zone_state"] = {}
+        if arm_types:
+            self._extra_state_attributes["arm_types"] = arm_types
+        if emergency_types:
+            self._extra_state_attributes["emergency_types"] = emergency_types
 
     async def _update_callback(self, device, message):
         """Update state attributes in hass after receiving a Websocket update for our item id/parent device id."""
         _LOGGER.debug(message)
 
-        # Message will be False when a Websocket disconnect is detected
         if message is False:
             self._attr_available = False
         elif message["evtName"] == "OnDataToUI":
             self._attr_available = True
             data = message["data"]
-            # Extra handling for alarm specific messages
             if "partition_state" in data:
                 data = data["partition_state"]
                 for key, value in data.items():
@@ -228,10 +248,7 @@ class Control4AlarmControlPanel(Control4Entity, AlarmControlPanelEntity):  # typ
         self.async_write_ha_state()
 
     def create_api_object(self):
-        """Create a pyControl4 device object.
-
-        This exists so the director token used is always the latest one, without needing to re-init the entire entity.
-        """
+        """Create a pyControl4 device object."""
         return C4SecurityPanel(self.entry_data[CONF_DIRECTOR], self._idx)
 
     @cached_property
@@ -265,66 +282,177 @@ class Control4AlarmControlPanel(Control4Entity, AlarmControlPanelEntity):  # typ
             flags |= AlarmControlPanelEntityFeature.TRIGGER
         return flags
 
+    def _partition_state_value(self) -> str | None:
+        """Return partition state from PARTITION_STATE or websocket 'state' attr."""
+        attrs = self.extra_state_attributes
+        partition = attrs.get(CONTROL4_PARTITION_STATE_VAR)
+        if partition:
+            return str(partition)
+        raw = attrs.get("state")
+        if raw:
+            return str(raw)
+        return None
+
+    def _is_triggered(self) -> bool:
+        """Return True when the panel reports an active alarm."""
+        attrs = self.extra_state_attributes
+        alarm_flag = attrs.get(CONTROL4_ALARM_STATE_VAR)
+        if alarm_flag is not None and str(alarm_flag) not in ("0", "", "False", "false"):
+            try:
+                if int(alarm_flag) == 1:
+                    return True
+            except (TypeError, ValueError):
+                if str(alarm_flag).lower() in ("true", "yes", "on"):
+                    return True
+        alarm_type = attrs.get(CONTROL4_ALARM_TYPE_VAR)
+        return bool(alarm_type and str(alarm_type).strip())
+
+    def _armed_state_from_type(self, armed_type: str | None) -> AlarmControlPanelState | None:
+        """Map Control4 armed type string to HA alarm state."""
+        if not armed_type:
+            return None
+        if armed_type == self.entry_data[CONF_ALARM_AWAY_MODE]:
+            return AlarmControlPanelState.ARMED_AWAY
+        if armed_type == self.entry_data[CONF_ALARM_HOME_MODE]:
+            return AlarmControlPanelState.ARMED_HOME
+        if armed_type == self.entry_data[CONF_ALARM_NIGHT_MODE]:
+            return AlarmControlPanelState.ARMED_NIGHT
+        if armed_type == self.entry_data[CONF_ALARM_CUSTOM_BYPASS_MODE]:
+            return AlarmControlPanelState.ARMED_CUSTOM_BYPASS
+        if armed_type == self.entry_data[CONF_ALARM_VACATION_MODE]:
+            return AlarmControlPanelState.ARMED_VACATION
+        return None
+
+    def _armed_state_from_partition(self, partition_state: str) -> AlarmControlPanelState | None:
+        """Map partition state that embeds arm mode."""
+        armed_type = self.extra_state_attributes.get(CONTROL4_ARMED_TYPE_VAR)
+        mapped = self._armed_state_from_type(
+            str(armed_type) if armed_type else None
+        )
+        if mapped:
+            return mapped
+
+        if partition_state == CONTROL4_ARMED_AWAY_STATE:
+            return AlarmControlPanelState.ARMED_AWAY
+        if partition_state == CONTROL4_ARMED_HOME_STATE:
+            return AlarmControlPanelState.ARMED_HOME
+        if partition_state == CONTROL4_ARMED_STATE:
+            return AlarmControlPanelState.ARMED_AWAY
+
+        lowered = partition_state.lower()
+        for option_key, ha_state in (
+            (CONF_ALARM_AWAY_MODE, AlarmControlPanelState.ARMED_AWAY),
+            (CONF_ALARM_HOME_MODE, AlarmControlPanelState.ARMED_HOME),
+            (CONF_ALARM_NIGHT_MODE, AlarmControlPanelState.ARMED_NIGHT),
+            (CONF_ALARM_CUSTOM_BYPASS_MODE, AlarmControlPanelState.ARMED_CUSTOM_BYPASS),
+            (CONF_ALARM_VACATION_MODE, AlarmControlPanelState.ARMED_VACATION),
+        ):
+            mode_name = self.entry_data.get(option_key)
+            if mode_name and mode_name.lower() in lowered:
+                return ha_state
+        return None
+
+    def _armed_state_from_flags(self) -> AlarmControlPanelState | None:
+        """Fallback using HOME_STATE / AWAY_STATE / DISARMED_STATE flags."""
+        attrs = self.extra_state_attributes
+
+        def _flag(name: str) -> bool:
+            value = attrs.get(name)
+            if value is None:
+                return False
+            try:
+                return int(value) == 1
+            except (TypeError, ValueError):
+                return str(value).lower() in ("true", "yes", "on", "1")
+
+        if _flag(CONTROL4_DISARMED_VAR):
+            return AlarmControlPanelState.DISARMED
+        if _flag(CONTROL4_ARMED_HOME_VAR):
+            return AlarmControlPanelState.ARMED_HOME
+        if _flag(CONTROL4_ARMED_AWAY_VAR):
+            return AlarmControlPanelState.ARMED_AWAY
+        return None
+
     @property
     def alarm_state(self) -> AlarmControlPanelState | None:  # type: ignore[override]
         """Return the state of the device."""
-        partition_state = self.extra_state_attributes.get(CONTROL4_PARTITION_STATE_VAR)
+        if self._is_triggered():
+            return AlarmControlPanelState.TRIGGERED
+
+        partition_state = self._partition_state_value()
         if partition_state == CONTROL4_EXIT_DELAY_STATE:
             return AlarmControlPanelState.ARMING
         if partition_state == CONTROL4_ENTRY_DELAY_STATE:
             return AlarmControlPanelState.PENDING
-        if (
-            partition_state == CONTROL4_DISARMED_NOT_READY_STATE
-            or partition_state == CONTROL4_DISARMED_READY_STATE
+        if partition_state in (
+            CONTROL4_DISARMED_NOT_READY_STATE,
+            CONTROL4_DISARMED_READY_STATE,
         ):
             return AlarmControlPanelState.DISARMED
-        if partition_state == CONTROL4_ARMED_STATE:
-            armed_type = self.extra_state_attributes.get(CONTROL4_ARMED_TYPE_VAR)
-            if armed_type == self.entry_data[CONF_ALARM_AWAY_MODE]:
-                return AlarmControlPanelState.ARMED_AWAY
-            if armed_type == self.entry_data[CONF_ALARM_HOME_MODE]:
-                return AlarmControlPanelState.ARMED_HOME
-            if armed_type == self.entry_data[CONF_ALARM_NIGHT_MODE]:
-                return AlarmControlPanelState.ARMED_NIGHT
-            if armed_type == self.entry_data[CONF_ALARM_CUSTOM_BYPASS_MODE]:
-                return AlarmControlPanelState.ARMED_CUSTOM_BYPASS
-            if armed_type == self.entry_data[CONF_ALARM_VACATION_MODE]:
-                return AlarmControlPanelState.ARMED_VACATION
-        alarm_state = self.extra_state_attributes.get(CONTROL4_ALARM_TYPE_VAR)
-        if alarm_state:
-            return AlarmControlPanelState.TRIGGERED
+
+        if partition_state and "ARMED" in partition_state:
+            armed = self._armed_state_from_partition(partition_state)
+            if armed:
+                return armed
+
+        flag_state = self._armed_state_from_flags()
+        if flag_state is not None:
+            return flag_state
 
         return None
+
+    async def _async_refresh_panel_state(self) -> None:
+        """Poll director for partition/armed state after a command."""
+        c4_alarm = self.create_api_object()
+        try:
+            partition = await c4_alarm.get_partition_state()
+            if partition:
+                self._extra_state_attributes[CONTROL4_PARTITION_STATE_VAR] = partition
+            armed_type = await c4_alarm.get_armed_type()
+            if armed_type is not None:
+                self._extra_state_attributes[CONTROL4_ARMED_TYPE_VAR] = armed_type
+            alarm_active = await c4_alarm.get_alarm_state()
+            if alarm_active is not None:
+                self._extra_state_attributes[CONTROL4_ALARM_STATE_VAR] = int(alarm_active)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Failed to refresh alarm panel state for %s", self._idx)
+        self.async_write_ha_state()
 
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
         c4_alarm = self.create_api_object()
         await c4_alarm.set_arm(code or "", self.entry_data[CONF_ALARM_AWAY_MODE])
+        await self._async_refresh_panel_state()
 
     async def async_alarm_arm_home(self, code=None):
         """Send arm home command."""
         c4_alarm = self.create_api_object()
         await c4_alarm.set_arm(code or "", self.entry_data[CONF_ALARM_HOME_MODE])
+        await self._async_refresh_panel_state()
 
     async def async_alarm_arm_night(self, code=None):
         """Send arm night command."""
         c4_alarm = self.create_api_object()
         await c4_alarm.set_arm(code or "", self.entry_data[CONF_ALARM_NIGHT_MODE])
+        await self._async_refresh_panel_state()
 
     async def async_alarm_arm_custom_bypass(self, code=None):
         """Send arm custom bypass command."""
         c4_alarm = self.create_api_object()
         await c4_alarm.set_arm(code or "", self.entry_data[CONF_ALARM_CUSTOM_BYPASS_MODE])
+        await self._async_refresh_panel_state()
 
     async def async_alarm_arm_vacation(self, code=None):
         """Send arm vacation command."""
         c4_alarm = self.create_api_object()
         await c4_alarm.set_arm(code or "", self.entry_data[CONF_ALARM_VACATION_MODE])
+        await self._async_refresh_panel_state()
 
     async def async_alarm_disarm(self, code=None):
         """Send disarm command."""
         c4_alarm = self.create_api_object()
         await c4_alarm.set_disarm(code or "")
+        await self._async_refresh_panel_state()
 
     async def async_alarm_trigger(self, code=None):
         """Send trigger/emergency command."""
@@ -337,9 +465,25 @@ class Control4AlarmControlPanel(Control4Entity, AlarmControlPanelEntity):  # typ
             self._emergency_types[0],
         )
         await c4_alarm.trigger_emergency(emergency_type)
+        await self._async_refresh_panel_state()
+
+    async def async_trigger_emergency(self, emergency_type: str) -> None:
+        """Trigger a specific emergency type supported by this panel."""
+        if emergency_type not in self._emergency_types:
+            _LOGGER.warning(
+                "Emergency type %s not supported on %s (available: %s)",
+                emergency_type,
+                self.entity_id,
+                self._emergency_types,
+            )
+            return
+        c4_alarm = self.create_api_object()
+        await c4_alarm.trigger_emergency(emergency_type)
+        await self._async_refresh_panel_state()
 
     async def send_alarm_keystrokes(self, keystrokes):
         """Send custom keystrokes."""
         c4_alarm = self.create_api_object()
         for key in keystrokes:
             await c4_alarm.send_key_press(key)
+        await self._async_refresh_panel_state()

--- a/custom_components/control4/alarm_utils.py
+++ b/custom_components/control4/alarm_utils.py
@@ -1,0 +1,177 @@
+"""Shared helpers for Control4 alarm control panel."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_ALARM_ARM_STATES,
+    CONF_ALARM_AWAY_MODE,
+    CONF_ALARM_CUSTOM_BYPASS_MODE,
+    CONF_ALARM_HOME_MODE,
+    CONF_ALARM_NIGHT_MODE,
+    CONF_ALARM_VACATION_MODE,
+    DEFAULT_ALARM_AWAY_MODE,
+    DEFAULT_ALARM_CUSTOM_BYPASS_MODE,
+    DEFAULT_ALARM_HOME_MODE,
+    DEFAULT_ALARM_NIGHT_MODE,
+    DEFAULT_ALARM_VACATION_MODE,
+)
+
+CONTROL4_PARTITION_STATE_VAR = "PARTITION_STATE"
+
+
+def parse_arm_types_from_capabilities(capabilities: dict | None) -> list[str]:
+    """Return arm type names from Director item capabilities."""
+    if not capabilities:
+        return []
+    types: list[str] = []
+    for key in ("arm_types", "arm_states"):
+        raw = capabilities.get(key, "")
+        if raw:
+            types.extend(t.strip() for t in str(raw).split(",") if t.strip())
+    # Preserve order, dedupe
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for name in types:
+        if name not in seen:
+            seen.add(name)
+            ordered.append(name)
+    return ordered
+
+
+def merge_arm_types_into_cache(cache: set[str], arm_types: list[str]) -> None:
+    """Add discovered arm types to the integration arm-state choice cache."""
+    for arm_type in arm_types:
+        if arm_type:
+            cache.add(arm_type)
+
+
+def _match_arm_type(arm_types: list[str], candidates: tuple[str, ...]) -> str | None:
+    """Return the first arm type matching any candidate (case-insensitive)."""
+    lowered = {t.lower(): t for t in arm_types}
+    for candidate in candidates:
+        match = lowered.get(candidate.lower())
+        if match:
+            return match
+    return None
+
+
+def auto_map_ha_modes(arm_types: list[str]) -> dict[str, str]:
+    """Map Control4 arm type names to HA alarm mode option keys."""
+    if not arm_types:
+        return {}
+
+    mapping: dict[str, str] = {}
+    away = _match_arm_type(arm_types, ("Away",))
+    if away:
+        mapping[CONF_ALARM_AWAY_MODE] = away
+
+    home = _match_arm_type(arm_types, ("Stay", "Home"))
+    if home:
+        mapping[CONF_ALARM_HOME_MODE] = home
+
+    night = _match_arm_type(arm_types, ("Night",))
+    if night:
+        mapping[CONF_ALARM_NIGHT_MODE] = night
+
+    vacation = _match_arm_type(arm_types, ("Vacation",))
+    if vacation:
+        mapping[CONF_ALARM_VACATION_MODE] = vacation
+
+    custom = _match_arm_type(arm_types, ("Bypass", "Custom"))
+    if custom:
+        mapping[CONF_ALARM_CUSTOM_BYPASS_MODE] = custom
+
+    return mapping
+
+
+def apply_auto_mapped_modes(
+    entry_options: dict,
+    entry_data: dict,
+    arm_types: list[str],
+) -> dict | None:
+    """Apply auto-mapped modes when user options are still default. Returns new options if changed."""
+    auto_mapped = auto_map_ha_modes(arm_types)
+    if not auto_mapped:
+        return None
+
+    defaults = {
+        CONF_ALARM_AWAY_MODE: DEFAULT_ALARM_AWAY_MODE,
+        CONF_ALARM_HOME_MODE: DEFAULT_ALARM_HOME_MODE,
+        CONF_ALARM_NIGHT_MODE: DEFAULT_ALARM_NIGHT_MODE,
+        CONF_ALARM_CUSTOM_BYPASS_MODE: DEFAULT_ALARM_CUSTOM_BYPASS_MODE,
+        CONF_ALARM_VACATION_MODE: DEFAULT_ALARM_VACATION_MODE,
+    }
+
+    new_options = dict(entry_options)
+    changed = False
+    for option_key, default_value in defaults.items():
+        current = entry_options.get(option_key, default_value)
+        if current != default_value:
+            continue
+        mapped = auto_mapped.get(option_key)
+        if mapped and mapped != default_value:
+            new_options[option_key] = mapped
+            entry_data[option_key] = mapped
+            changed = True
+
+    return new_options if changed else None
+
+
+def is_usable_partition(item_attributes: dict, arm_types: list[str]) -> bool:
+    """Return True if this security item is a usable alarm partition."""
+    if arm_types:
+        return True
+    return CONTROL4_PARTITION_STATE_VAR in item_attributes
+
+
+def arm_state_choices(entry_data: dict) -> list[str]:
+    """Return sorted arm state choices including (not set)."""
+    choices = set(entry_data.get(CONF_ALARM_ARM_STATES, set()))
+    choices.update(
+        {
+            DEFAULT_ALARM_AWAY_MODE,
+            DEFAULT_ALARM_HOME_MODE,
+            DEFAULT_ALARM_NIGHT_MODE,
+            DEFAULT_ALARM_CUSTOM_BYPASS_MODE,
+            DEFAULT_ALARM_VACATION_MODE,
+        }
+    )
+    return sorted(choices)
+
+
+async def async_discover_alarm_arm_types(
+    hass: HomeAssistant, entry: ConfigEntry, entry_data: dict
+) -> list[str]:
+    """Discover arm types from security items and populate CONF_ALARM_ARM_STATES."""
+    from pyControl4.alarm import C4SecurityPanel
+
+    from . import get_items_of_category
+    from .const import CONF_DIRECTOR, CONTROL4_ENTITY_TYPE
+
+    director = entry_data[CONF_DIRECTOR]
+    all_arm_types: list[str] = []
+
+    try:
+        items = await get_items_of_category(hass, entry, "security")
+    except Exception:  # noqa: BLE001
+        return all_arm_types
+
+    for item in items:
+        if item.get("type") != CONTROL4_ENTITY_TYPE or not item.get("id"):
+            continue
+        cap_types = parse_arm_types_from_capabilities(item.get("capabilities"))
+        merge_arm_types_into_cache(entry_data[CONF_ALARM_ARM_STATES], cap_types)
+        c4_alarm = C4SecurityPanel(director, item["id"])
+        try:
+            item_arm_types = await c4_alarm.get_arm_types()
+        except Exception:  # noqa: BLE001
+            item_arm_types = []
+        if not item_arm_types:
+            item_arm_types = cap_types
+        merge_arm_types_into_cache(entry_data[CONF_ALARM_ARM_STATES], item_arm_types)
+        all_arm_types.extend(item_arm_types)
+
+    return list(dict.fromkeys(all_arm_types))

--- a/custom_components/control4/config_flow.py
+++ b/custom_components/control4/config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 
+from .alarm_utils import arm_state_choices, auto_map_ha_modes
 from .const import (
     CONF_ALARM_ARM_STATES,
     CONF_ALARM_AWAY_MODE,
@@ -206,21 +207,42 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             _LOGGER.debug(user_input)
             return self.async_create_entry(title="", data=user_input)
 
-        # TODO: figure out how to accept empty strings to disable modes
-        # TODO: figure out how to only show alarm options if a alarm_control_panel entity exists
         self.entry_data = self.hass.data[DOMAIN][self._config_entry.entry_id]
 
-        # Minimal approach: use existing cached arm states only
-        arm_state_choices = set(self.entry_data.get(CONF_ALARM_ARM_STATES, [])) or {
-            DEFAULT_ALARM_AWAY_MODE
-        }
-
-        # Determine if a security panel is effectively present (has real arm states)
+        choices = arm_state_choices(self.entry_data)
         has_security = any(
-            x.strip() and x.strip() != DEFAULT_ALARM_AWAY_MODE for x in arm_state_choices
+            x.strip()
+            and x.strip()
+            not in {
+                DEFAULT_ALARM_AWAY_MODE,
+                DEFAULT_ALARM_HOME_MODE,
+                DEFAULT_ALARM_NIGHT_MODE,
+                DEFAULT_ALARM_CUSTOM_BYPASS_MODE,
+                DEFAULT_ALARM_VACATION_MODE,
+            }
+            for x in self.entry_data.get(CONF_ALARM_ARM_STATES, set())
         )
 
-        # Always include scan interval; include alarm options only if we have a panel
+        auto_defaults = auto_map_ha_modes(
+            [
+                x
+                for x in self.entry_data.get(CONF_ALARM_ARM_STATES, set())
+                if x
+                not in {
+                    DEFAULT_ALARM_AWAY_MODE,
+                    DEFAULT_ALARM_HOME_MODE,
+                    DEFAULT_ALARM_NIGHT_MODE,
+                    DEFAULT_ALARM_CUSTOM_BYPASS_MODE,
+                    DEFAULT_ALARM_VACATION_MODE,
+                }
+            ]
+        )
+
+        def _default_mode(option_key: str, default_not_set: str) -> str:
+            return self._config_entry.options.get(
+                option_key, auto_defaults.get(option_key, default_not_set)
+            )
+
         if has_security:
             data_schema = vol.Schema(
                 {
@@ -232,34 +254,28 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ): vol.All(cv.positive_int, vol.Clamp(min=MIN_SCAN_INTERVAL)),
                     vol.Optional(
                         CONF_ALARM_AWAY_MODE,
-                        default=self._config_entry.options.get(
-                            CONF_ALARM_AWAY_MODE, DEFAULT_ALARM_AWAY_MODE
-                        ),
-                    ): vol.In(sorted(arm_state_choices)),
+                        default=_default_mode(CONF_ALARM_AWAY_MODE, DEFAULT_ALARM_AWAY_MODE),
+                    ): vol.In(choices),
                     vol.Optional(
                         CONF_ALARM_HOME_MODE,
-                        default=self._config_entry.options.get(
-                            CONF_ALARM_HOME_MODE, DEFAULT_ALARM_HOME_MODE
-                        ),
-                    ): vol.In(sorted(arm_state_choices)),
+                        default=_default_mode(CONF_ALARM_HOME_MODE, DEFAULT_ALARM_HOME_MODE),
+                    ): vol.In(choices),
                     vol.Optional(
                         CONF_ALARM_NIGHT_MODE,
-                        default=self._config_entry.options.get(
-                            CONF_ALARM_NIGHT_MODE, DEFAULT_ALARM_NIGHT_MODE
-                        ),
-                    ): vol.In(sorted(arm_state_choices)),
+                        default=_default_mode(CONF_ALARM_NIGHT_MODE, DEFAULT_ALARM_NIGHT_MODE),
+                    ): vol.In(choices),
                     vol.Optional(
                         CONF_ALARM_CUSTOM_BYPASS_MODE,
-                        default=self._config_entry.options.get(
+                        default=_default_mode(
                             CONF_ALARM_CUSTOM_BYPASS_MODE, DEFAULT_ALARM_CUSTOM_BYPASS_MODE
                         ),
-                    ): vol.In(sorted(arm_state_choices)),
+                    ): vol.In(choices),
                     vol.Optional(
                         CONF_ALARM_VACATION_MODE,
-                        default=self._config_entry.options.get(
+                        default=_default_mode(
                             CONF_ALARM_VACATION_MODE, DEFAULT_ALARM_VACATION_MODE
                         ),
-                    ): vol.In(sorted(arm_state_choices)),
+                    ): vol.In(choices),
                 },
                 required=False,
             )

--- a/custom_components/control4/manifest.json
+++ b/custom_components/control4/manifest.json
@@ -9,10 +9,10 @@
       "st": "c4:director"
     }
   ],
-  "codeowners": ["@lawtancool"],
+  "codeowners": ["@lawtancool", "@armedad"],
   "integration_type": "hub",
   "iot_class": "local_push",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "issue_tracker": "https://github.com/lawtancool/hass-control4/issues",
   "dependencies": []
 }

--- a/custom_components/control4/services.yaml
+++ b/custom_components/control4/services.yaml
@@ -7,3 +7,13 @@ send_alarm_keystrokes:
     keystrokes:
       description: String of keystrokes.
       example: "*101#"
+
+trigger_emergency:
+  description: Triggers a specific emergency on a Control4 alarm control panel.
+  fields:
+    entity_id:
+      description: Name(s) of the alarm control panel entities.
+      example: "alarm_control_panel.security_system"
+    emergency_type:
+      description: Emergency type supported by the panel (Fire, Medical, Panic, or Police).
+      example: "Fire"


### PR DESCRIPTION
Adds a fuller Control4 alarm panel in Home Assistant: discovered arm types, auto-mapping Stay/Away on first load, virtual keypad keystrokes, and emergency triggers when the panel supports them.

Use the Security System partition (the one with PARTITION_STATE) as the primary entity. The companion Security Panel UI item stays disabled when it is not a usable partition. You can still change mode mapping under Configure.

Tested against a live Control4 security panel.